### PR TITLE
Defer artist bucket build in artists view

### DIFF
--- a/src/renderer/src/App.jsx
+++ b/src/renderer/src/App.jsx
@@ -3096,6 +3096,8 @@ export default function App() {
   const [artistSortMode, setArtistSortMode] = useState('default')
   const [artistSortOpen, setArtistSortOpen] = useState(false)
   const artistSortRef = useRef(null)
+  const [artistBucketsDeferred, setArtistBucketsDeferred] = useState(false)
+  const artistBucketsDeferredRef = useRef(false)
   const [folderSortMode, setFolderSortMode] = useState('default') // 'default' | 'dateAsc' | 'dateDesc'
   const [folderSortOpen, setFolderSortOpen] = useState(false)
   const folderSortRef = useRef(null)
@@ -14798,8 +14800,37 @@ export default function App() {
 
   const folderGroups = listMode === 'folders' ? folderBuckets : []
 
+  useEffect(() => {
+    if (listMode === 'artists') {
+      if (!artistBucketsDeferredRef.current) {
+        const scheduleBuild = () => {
+          if (typeof window.requestIdleCallback === 'function') {
+            window.requestIdleCallback(() => {
+              startTransition(() => {
+                setArtistBucketsDeferred(true)
+              })
+            }, { timeout: 500 })
+          } else {
+            window.setTimeout(() => {
+              startTransition(() => {
+                setArtistBucketsDeferred(true)
+              })
+            }, 100)
+          }
+        }
+        scheduleBuild()
+      }
+    } else {
+      artistBucketsDeferredRef.current = false
+      setArtistBucketsDeferred(false)
+    }
+  }, [listMode])
+
+  const shouldBuildArtistBucketsDeferred =
+    listMode === 'artists' ? artistBucketsDeferred : shouldBuildArtistBuckets
+
   const artistBucketBase = useMemo(() => {
-    if (!shouldBuildArtistBuckets) return []
+    if (!shouldBuildArtistBucketsDeferred) return []
     return measureLibraryPerf('artist-buckets-build', () => {
       const unknownArtist = t('artists.unknown', 'Unknown Artist')
       const identityTrackMetaMap = trackMetaMapRef.current || {}

--- a/src/renderer/src/components/BgImageEditor.jsx
+++ b/src/renderer/src/components/BgImageEditor.jsx
@@ -1,4 +1,4 @@
-﻿﻿import { useState, useRef, useEffect, useCallback } from 'react'
+﻿﻿﻿﻿import { useState, useRef, useEffect, useCallback } from 'react'
 
 export default function BgImageEditor({
   imageDataUrl,


### PR DESCRIPTION
Introduce deferred building of artist buckets to avoid expensive work when switching to the artists list. Adds artistBucketsDeferred state and artistBucketsDeferredRef to track scheduling, and an effect that uses requestIdleCallback (fallback to setTimeout) with startTransition to set the deferred flag. When leaving the artists view the deferred state is reset. The memo that builds artistBucketBase now checks shouldBuildArtistBucketsDeferred to skip work until scheduled. Also includes a tiny import whitespace tweak in BgImageEditor.jsx.