### PR TITLE
Sync remaining speed progress branch fixes to main

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,10 @@ CMakeCache.txt
 cmake_install.cmake
 compile_commands.json
 
+# Local binary tools downloaded outside source control
+electron-app/tools/ffmpeg.exe
+electron-app/tools/ffprobe.exe
+
 # Electron Builder artifacts
 *.blockmap
 *.AppImage

--- a/docs/BUGFIX_SPEED_PROGRESS_2026-05-17.md
+++ b/docs/BUGFIX_SPEED_PROGRESS_2026-05-17.md
@@ -1,0 +1,47 @@
+# BUG-2026-05-17-001: Playback speed progress interpolation
+
+## Markdown Summary
+
+- Bug ID: BUG-2026-05-17-001
+- Severity: High
+- Category: Functional playback UI regression
+- Components: Player progress bar, lyrics playback clock
+- Files:
+  - `src/renderer/components/player/PlayerBar.tsx`
+  - `src/renderer/pages/LyricsPage.tsx`
+  - `src/renderer/components/player/PlayerBar.test.tsx`
+  - `src/renderer/pages/LyricsPage.test.tsx`
+- Current behavior: At high playback speed, a brief stale audio status update could make the progress bar and active lyric line jump backward.
+- Expected behavior: Playback speed should advance the estimated media position, but it should not shorten the wall-clock lag window used to bridge stale status updates.
+- Root cause: The interpolation logic multiplied elapsed wall-clock time by playback rate before both estimating media position and checking `maxInterpolatedStatusGapSeconds`.
+- Fix: Split elapsed time into wall-clock elapsed seconds and playback-rate-adjusted media elapsed seconds. Use media elapsed time for position estimation and wall-clock elapsed time for stale-status bridge eligibility.
+- Follow-up fix: Playback-rate changes are now treated as a clock rebase boundary. If the returned source position is discontinuous from the locally estimated continuous position, the UI keeps the continuous estimate instead of jumping.
+- Validation:
+  - `npx vitest run src/renderer/components/player/PlayerBar.test.tsx src/renderer/pages/LyricsPage.test.tsx`
+  - `npm run typecheck`
+  - `npx vitest run`
+
+## JSON Record
+
+```json
+{
+  "bugId": "BUG-2026-05-17-001",
+  "severity": "high",
+  "category": "functional",
+  "component": "playback-clock",
+  "rootCause": "playback-rate-adjusted elapsed time was reused as the wall-clock stale-status bridge interval",
+  "fix": "separate wall elapsed seconds from media elapsed seconds and rebase discontinuous playback-rate changes against the continuous local clock",
+  "verification": {
+    "targetedVitest": "passed",
+    "typecheck": "passed",
+    "fullVitest": "passed"
+  }
+}
+```
+
+## CSV Record
+
+```csv
+bug_id,severity,category,component,current_behavior,expected_behavior,verification
+BUG-2026-05-17-001,High,Functional,playback-clock,"high-speed playback or speed changes could make progress and lyrics jump on stale status","speed changes keep continuous media time without shrinking stale-status wall-clock bridge window","targeted vitest; typecheck; full vitest"
+```

--- a/src/main/audio/AudioCore.test.ts
+++ b/src/main/audio/AudioCore.test.ts
@@ -211,6 +211,29 @@ class FailingDecoder extends FakeDecoder {
   }
 }
 
+class ControlledFailingDecoder extends FakeDecoder {
+  private rejectDone: ((error: Error) => void) | null = null;
+
+  override decodeLocalFile(request: PcmDecodeRequest): DecoderRun {
+    this.decodeRequests.push(request);
+    const stream = new PassThrough();
+
+    return {
+      stream,
+      stop: vi.fn(() => {
+        stream.destroy();
+      }),
+      done: new Promise<void>((_resolve, reject) => {
+        this.rejectDone = reject;
+      }),
+    };
+  }
+
+  fail(error: Error): void {
+    this.rejectDone?.(error);
+  }
+}
+
 class StreamErrorDecoder extends FakeDecoder {
   private stream: PassThrough | null = null;
 
@@ -1401,6 +1424,46 @@ describe('Audio Core sample-rate regression guard', () => {
     expect(fallbackBridge.startOptions?.deviceName).toBeUndefined();
     expect(status.state).toBe('playing');
     expect(status.warnings).toContain('shared_output_fell_back_to_default_device');
+  });
+
+  it('lets a recovery handler claim post-start expired FFmpeg stream URLs before fatal reporting', async () => {
+    const decoder = new ControlledFailingDecoder(
+      new Map([['https://m801.music.126.net/token/song.mp3?auth=old', {
+        ...probe('https://m801.music.126.net/token/song.mp3?auth=old', 44100),
+        codec: 'mp3',
+      }]]),
+    );
+    const reportAudioError = vi.fn();
+    const recoverAudioError = vi.fn(() => true);
+    const session = new AudioSession({
+      decoder,
+      deviceService: { listDevices: () => [] },
+      createBridge: () => new FakeBridge(44100),
+      reportAudioError,
+      logger: noopLogger,
+      disableWatchdogTimer: true,
+    });
+
+    session.setAudioErrorRecoveryHandler(recoverAudioError);
+    await session.playLocalFile({
+      filePath: 'https://m801.music.126.net/token/song.mp3?auth=old',
+      trackId: 'streaming:netease:1442466883',
+      output: { outputMode: 'exclusive' },
+    });
+
+    const error = Object.assign(
+      new Error('ffmpeg_exit_code_3436169992; kind="http_expired_or_forbidden"; stderr="Server returned 403 Forbidden"'),
+      { ffmpegErrorKind: 'http_expired_or_forbidden' },
+    );
+    decoder.fail(error);
+
+    await expect.poll(() => session.getStatus().state).toBe('loading');
+    expect(recoverAudioError).toHaveBeenCalledWith(error, expect.objectContaining({
+      state: 'playing',
+      currentTrackId: 'streaming:netease:1442466883',
+      currentFilePath: 'https://m801.music.126.net/token/song.mp3?auth=old',
+    }));
+    expect(reportAudioError).not.toHaveBeenCalled();
   });
 
   it('marks selected shared device timeout recovery when the default shared device starts', async () => {

--- a/src/main/audio/AudioSession.ts
+++ b/src/main/audio/AudioSession.ts
@@ -100,6 +100,8 @@ type PreparedLocalProbeUse = {
   ageMs: number;
 };
 
+export type AudioErrorRecoveryHandler = (error: Error, status: AudioStatus) => boolean;
+
 export type AudioSessionDependencies = {
   decoder?: DecoderPipelineLike;
   juceDecoder?: JuceDecodePipelineLike;
@@ -941,6 +943,7 @@ export class AudioSession extends EventEmitter {
   private readonly preparedLocalPlaybackCache = new Map<string, PreparedLocalPlaybackItem>();
   private readonly sharedStabilityMemory = new Map<string, { tier: SharedStabilityTier; expiresAt: number }>();
   private lastSharedStabilityRecoveryKey: string | null = null;
+  private audioErrorRecoveryHandler: AudioErrorRecoveryHandler | null = null;
   private readonly eqStateListener = (): void => {
     this.emitStatus();
   };
@@ -978,6 +981,10 @@ export class AudioSession extends EventEmitter {
 
   async listDevicesAsync(): Promise<AudioDeviceInfo[]> {
     return this.deviceService.listDevicesAsync?.() ?? this.deviceService.listDevices();
+  }
+
+  setAudioErrorRecoveryHandler(handler: AudioErrorRecoveryHandler | null): void {
+    this.audioErrorRecoveryHandler = handler;
   }
 
   async openAsioControlPanel(settings: Pick<AudioOutputSettings, 'deviceIndex' | 'deviceName'>): Promise<void> {
@@ -3897,6 +3904,16 @@ export class AudioSession extends EventEmitter {
 
   private handleError(error: Error): void {
     this.logger(`[AudioSession] ${error.message}`);
+    if (this.tryClaimRecoverableAudioError(error)) {
+      this.stopResources();
+      this.errorMessage = null;
+      this.state = 'loading';
+      this.hostStatus = 'starting';
+      this.resetWatchdogProgress();
+      this.emitStatus();
+      return;
+    }
+
     this.stopResources();
     this.errorMessage = error.message;
     this.state = 'error';
@@ -3905,6 +3922,21 @@ export class AudioSession extends EventEmitter {
     this.resetWatchdogProgress();
     this.emit('error', error, this.getStatus());
     this.emitStatus();
+  }
+
+  private tryClaimRecoverableAudioError(error: Error): boolean {
+    if (!this.audioErrorRecoveryHandler) {
+      return false;
+    }
+
+    try {
+      return this.audioErrorRecoveryHandler(error, this.getStatus()) === true;
+    } catch (recoveryError) {
+      this.logger(`[AudioSession] audio error recovery handler failed: ${
+        recoveryError instanceof Error ? recoveryError.message : String(recoveryError)
+      }`);
+      return false;
+    }
   }
 
   private assertCurrentRun(token: number): void {

--- a/src/main/ipc/playbackIpc.test.ts
+++ b/src/main/ipc/playbackIpc.test.ts
@@ -1,3 +1,4 @@
+import { EventEmitter } from 'node:events';
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -147,6 +148,157 @@ describe('playback media prepare IPC', () => {
         fileSampleRate: 44100,
         channels: 2,
       }),
+    }));
+  });
+
+  it('refreshes an active streaming source when FFmpeg reports an expired CDN URL after playback started', async () => {
+    const handlers = new Map<string, (...args: unknown[]) => unknown>();
+    const reportAudioError = vi.fn();
+    const recovery = {
+      handler: null as ((error: Error, status: unknown) => boolean) | null,
+    };
+    let status = {
+      state: 'playing',
+      currentTrackId: null as string | null,
+      positionSeconds: 0,
+      durationSeconds: 239.932,
+      currentFilePath: null as string | null,
+    };
+    const playLocalFile = vi.fn(async (request: {
+      filePath: string;
+      trackId?: string;
+      startSeconds?: number;
+      probe?: { durationSeconds?: number };
+    }) => {
+      status = {
+        state: 'playing',
+        currentTrackId: request.trackId ?? null,
+        positionSeconds: request.startSeconds ?? 0,
+        durationSeconds: request.probe?.durationSeconds ?? status.durationSeconds,
+        currentFilePath: request.filePath,
+      };
+      return status;
+    });
+    const audioSession = Object.assign(new EventEmitter(), {
+      getStatus: () => status,
+      restorePlaybackMemory: vi.fn(),
+      playLocalFile,
+      setAudioErrorRecoveryHandler: vi.fn((handler: (error: Error, status: unknown) => boolean) => {
+        recovery.handler = handler;
+      }),
+    });
+    const invalidatePlayback = vi.fn();
+    const resolvePlayback = vi
+      .fn()
+      .mockResolvedValueOnce({
+        url: 'https://m801.music.126.net/token/song.mp3?auth=old',
+        sampleRate: 44100,
+        codec: 'mp3',
+        bitDepth: null,
+        bitrate: 320000,
+        headers: {
+          Referer: 'https://music.163.com/',
+        },
+        requiresProxy: false,
+      })
+      .mockResolvedValueOnce({
+        url: 'https://m701.music.126.net/token/song.mp3?auth=fresh',
+        sampleRate: 44100,
+        codec: 'mp3',
+        bitDepth: null,
+        bitrate: 320000,
+        headers: {
+          Referer: 'https://music.163.com/',
+        },
+        requiresProxy: false,
+      });
+
+    vi.doMock('electron', () => ({
+      dialog: { showOpenDialog: vi.fn() },
+      ipcMain: {
+        handle: vi.fn((channel: string, handler: (...args: unknown[]) => unknown) => {
+          handlers.set(channel, handler);
+        }),
+      },
+    }));
+    vi.doMock('../audio/AudioSession', () => ({
+      getAudioSession: () => audioSession,
+    }));
+    vi.doMock('../audio/PlaybackMemoryStore', () => ({
+      getPlaybackMemoryStore: () => ({
+        load: vi.fn(() => null),
+        save: vi.fn(),
+        clear: vi.fn(),
+      }),
+    }));
+    vi.doMock('../diagnostics/CrashReportService', () => ({
+      getCrashReportService: () => ({ reportAudioError }),
+    }));
+    vi.doMock('../integrations/smtc/SmtcStatusSync', () => ({ syncSmtcStatus: vi.fn() }));
+    vi.doMock('../library/remote/RemoteSourceService', () => ({
+      getRemoteSourceService: () => ({
+        setPlaybackActive: vi.fn(),
+        refreshTrackMetadata: vi.fn(),
+        createStreamUrl: vi.fn(),
+        backfillDuration: vi.fn(),
+      }),
+    }));
+    vi.doMock('../streaming/StreamingService', () => ({
+      getStreamingService: () => ({
+        resolvePlayback,
+        invalidatePlayback,
+      }),
+    }));
+    vi.doMock('../app/localFileOpen', () => ({ resolveLocalAudioFiles: vi.fn() }));
+
+    const { IpcChannels } = await import('../../shared/constants/ipcChannels');
+    const { registerPlaybackIpc } = await import('./playbackIpc');
+    registerPlaybackIpc();
+
+    const request = {
+      item: {
+        mediaType: 'streaming',
+        trackId: 'streaming:netease:1442466883',
+        provider: 'netease',
+        providerTrackId: '1442466883',
+        stableKey: 'streaming:netease:1442466883',
+        quality: 'high',
+        title: 'Expired CDN',
+        artist: 'Artist',
+        album: 'Album',
+        duration: 239.932,
+      },
+    };
+
+    await handlers.get(IpcChannels.PlaybackPlayMediaItem)?.({}, request);
+    expect(playLocalFile).toHaveBeenCalledWith(expect.objectContaining({
+      filePath: 'https://m801.music.126.net/token/song.mp3?auth=old',
+    }));
+
+    status = { ...status, positionSeconds: 0.09039979999978096 };
+    const expiredError = Object.assign(
+      new Error('ffmpeg_exit_code_3436169992; kind="http_expired_or_forbidden"; stderr="Server returned 403 Forbidden"'),
+      { ffmpegErrorKind: 'http_expired_or_forbidden' },
+    );
+
+    expect(recovery.handler?.(expiredError, status)).toBe(true);
+
+    await expect.poll(() => playLocalFile.mock.calls.length).toBe(2);
+    expect(invalidatePlayback).toHaveBeenCalledWith({
+      provider: 'netease',
+      providerTrackId: '1442466883',
+      quality: 'high',
+    });
+    expect(playLocalFile).toHaveBeenLastCalledWith(expect.objectContaining({
+      filePath: 'https://m701.music.126.net/token/song.mp3?auth=fresh',
+      startSeconds: 0.09039979999978096,
+      trackId: 'streaming:netease:1442466883',
+    }));
+    expect(reportAudioError).toHaveBeenCalledWith(expect.objectContaining({
+      message: expect.stringContaining('ffmpeg_exit_code_3436169992'),
+      phase: 'play-media-item-expired-url-retry',
+      severity: 'recoverable',
+      recovered: true,
     }));
   });
 

--- a/src/main/ipc/playbackIpc.ts
+++ b/src/main/ipc/playbackIpc.ts
@@ -2,7 +2,7 @@ import { dialog, ipcMain } from 'electron';
 import { SUPPORTED_AUDIO_DIALOG_EXTENSIONS } from '../../shared/constants/audioExtensions';
 import { IpcChannels } from '../../shared/constants/ipcChannels';
 import { normalizeAudioOutputModeForPlatform, normalizeAudioSharedBackendForPlatform } from '../../shared/utils/audioPlatformCapabilities';
-import type { AudioLatencyProfile, AudioOutputMode, AudioOutputSettings, AudioSharedBackend, PlaybackSpeedMode } from '../../shared/types/audio';
+import type { AudioLatencyProfile, AudioOutputMode, AudioOutputSettings, AudioSharedBackend, AudioStatus, PlaybackSpeedMode } from '../../shared/types/audio';
 import type {
   LocalFileResolveResult,
   PlaybackMediaStartRequest,
@@ -13,7 +13,7 @@ import type {
 } from '../../shared/types/playback';
 import type { PlayableTrack } from '../../shared/types/remoteSources';
 import { streamingProviderNames, type StreamingAudioQuality, type StreamingProviderName } from '../../shared/types/streaming';
-import { getAudioSession } from '../audio/AudioSession';
+import { getAudioSession, type AudioErrorRecoveryHandler } from '../audio/AudioSession';
 import { getPlaybackMemoryStore } from '../audio/PlaybackMemoryStore';
 import { getCrashReportService } from '../diagnostics/CrashReportService';
 import { syncSmtcStatus } from '../integrations/smtc/SmtcStatusSync';
@@ -28,6 +28,7 @@ const latencyProfiles = new Set<AudioLatencyProfile>(['stable', 'balanced', 'low
 const playbackSpeedModes = new Set<PlaybackSpeedMode>(['nightcore', 'daycore', 'speed']);
 const streamingProviders = new Set<StreamingProviderName>(streamingProviderNames);
 const preparedMediaTtlMs = 2 * 60 * 1000;
+const maxExpiredUrlRecoveryAttempts = 1;
 
 type PreparedMediaItem = {
   filePath: string;
@@ -36,7 +37,16 @@ type PreparedMediaItem = {
   durationSeconds: number | null;
 };
 
+type ActiveMediaPlayback = {
+  key: string;
+  request: PlaybackMediaStartRequest;
+  recoveryAttempts: number;
+  recoveryInFlight: boolean;
+};
+
 const preparedMediaCache = new Map<string, { expiresAt: number; prepared: PreparedMediaItem }>();
+let activeMediaPlayback: ActiveMediaPlayback | null = null;
+let audioErrorRecoveryRegistered = false;
 
 const isSupersededPlaybackRun = (error: unknown): boolean => {
   const message = error instanceof Error ? error.message : String(error);
@@ -162,8 +172,15 @@ const optionalStreamingQuality = (value: unknown): StreamingAudioQuality | undef
 const isHttpUrl = (value: string): boolean => /^https?:\/\//iu.test(value);
 
 const isLikelyExpiredUrlError = (error: unknown): boolean => {
+  if (error && typeof error === 'object') {
+    const kind = (error as { ffmpegErrorKind?: unknown }).ffmpegErrorKind;
+    if (typeof kind === 'string') {
+      return kind === 'http_expired_or_forbidden';
+    }
+  }
+
   const message = error instanceof Error ? error.message : String(error);
-  return /403|404|expired|forbidden|unauthorized|invalid data|server returned|http error/iu.test(message);
+  return /kind="http_expired_or_forbidden"|\b(?:401|403|404)\b|expired|forbidden|unauthorized|server returned 4\d\d|http error\s*4\d\d/iu.test(message);
 };
 
 const createPreparedMediaKey = (request: PlaybackMediaStartRequest): string => {
@@ -189,6 +206,24 @@ const createPreparedMediaKey = (request: PlaybackMediaStartRequest): string => {
   }
 
   return JSON.stringify({ mediaType: item.mediaType, trackId: item.trackId, path: item.path });
+};
+
+const setActiveMediaPlayback = (request: PlaybackMediaStartRequest): void => {
+  if (request.item.mediaType !== 'remote' && request.item.mediaType !== 'streaming') {
+    activeMediaPlayback = null;
+    return;
+  }
+
+  activeMediaPlayback = {
+    key: createPreparedMediaKey(request),
+    request,
+    recoveryAttempts: 0,
+    recoveryInFlight: false,
+  };
+};
+
+const clearActiveMediaPlayback = (): void => {
+  activeMediaPlayback = null;
 };
 
 const normalizeProbeHint = (value: unknown): PlaybackProbeHint | undefined => {
@@ -468,6 +503,112 @@ const reportPlaybackAudioError = (error: unknown, phase: string, details?: unkno
   });
 };
 
+const reportPlaybackAudioRecovery = (error: unknown, phase: string, details?: unknown): void => {
+  const normalized = error instanceof Error ? error : new Error(String(error));
+
+  getCrashReportService().reportAudioError({
+    message: normalized.message,
+    stack: normalized.stack,
+    phase,
+    severity: 'recoverable',
+    recovered: true,
+    details,
+    audioStatus: getAudioSession().getStatus(),
+  });
+};
+
+const clampRecoveryPositionSeconds = (status: AudioStatus): number => {
+  const positionSeconds = Number.isFinite(status.positionSeconds) ? Math.max(0, status.positionSeconds) : 0;
+  const durationSeconds = Number.isFinite(status.durationSeconds) && status.durationSeconds > 0 ? status.durationSeconds : Number.POSITIVE_INFINITY;
+
+  return Math.min(positionSeconds, durationSeconds);
+};
+
+const recoverActiveMediaPlaybackFromExpiredUrl = async (
+  active: ActiveMediaPlayback,
+  error: Error,
+  status: AudioStatus,
+): Promise<void> => {
+  const { key, request } = active;
+  let playbackStartAttempted = false;
+
+  try {
+    preparedMediaCache.delete(key);
+    const prepared = await resolveMediaItemForPlayback(request, { forceRefresh: true });
+    if (activeMediaPlayback !== active || activeMediaPlayback.key !== key) {
+      return;
+    }
+
+    const startSeconds = clampRecoveryPositionSeconds(status);
+    playbackStartAttempted = true;
+    await getAudioSession().playLocalFile({
+      filePath: prepared.filePath,
+      inputHeaders: prepared.inputHeaders,
+      trackId: request.item.trackId,
+      startSeconds,
+      output: request.output,
+      probe: prepared.probe,
+    });
+    savePlaybackMemoryNow();
+    const recoveredStatus = toPlaybackStatus();
+    if (request.item.mediaType === 'remote' && recoveredStatus.durationMs > 0) {
+      getRemoteSourceService().backfillDuration(request.item.trackId, recoveredStatus.durationMs / 1000);
+      getRemoteSourceService().setPlaybackActive(true);
+    }
+    void syncSmtcStatus();
+    reportPlaybackAudioRecovery(error, 'play-media-item-expired-url-retry', {
+      recovered: true,
+      mediaType: request.item.mediaType,
+      trackId: request.item.trackId,
+      provider: request.item.mediaType === 'streaming' ? request.item.provider : undefined,
+      providerTrackId: request.item.mediaType === 'streaming' ? request.item.providerTrackId : undefined,
+      startSeconds,
+      attempt: active.recoveryAttempts,
+    });
+  } catch (retryError) {
+    if (!playbackStartAttempted && !isSupersededPlaybackRun(retryError)) {
+      clearActiveMediaPlayback();
+      reportPlaybackAudioError(retryError, 'play-media-item-expired-url-refresh', {
+        request,
+        originalError: error.message,
+      });
+      getAudioSession().stop();
+    }
+  } finally {
+    if (activeMediaPlayback === active && activeMediaPlayback.key === key) {
+      activeMediaPlayback.recoveryInFlight = false;
+    }
+  }
+};
+
+const beginActiveMediaExpiredUrlRecovery: AudioErrorRecoveryHandler = (error, status) => {
+  const active = activeMediaPlayback;
+  if (!active || active.recoveryInFlight || active.recoveryAttempts >= maxExpiredUrlRecoveryAttempts) {
+    return false;
+  }
+
+  if ((active.request.item.mediaType !== 'streaming' && active.request.item.mediaType !== 'remote') || !isLikelyExpiredUrlError(error)) {
+    return false;
+  }
+
+  active.recoveryAttempts += 1;
+  active.recoveryInFlight = true;
+  void recoverActiveMediaPlaybackFromExpiredUrl(active, error, status);
+  return true;
+};
+
+const registerExpiredUrlRecovery = (): void => {
+  if (audioErrorRecoveryRegistered) {
+    return;
+  }
+
+  audioErrorRecoveryRegistered = true;
+  const session = getAudioSession() as ReturnType<typeof getAudioSession> & {
+    setAudioErrorRecoveryHandler?: (handler: AudioErrorRecoveryHandler | null) => void;
+  };
+  session.setAudioErrorRecoveryHandler?.(beginActiveMediaExpiredUrlRecovery);
+};
+
 let playbackMemoryRegistered = false;
 let lastPlaybackMemorySaveAt = 0;
 const playbackMemorySaveIntervalMs = 5000;
@@ -500,8 +641,10 @@ const registerPlaybackMemoryPersistence = (): void => {
 
 export const registerPlaybackIpc = (): void => {
   registerPlaybackMemoryPersistence();
+  registerExpiredUrlRecovery();
   ipcMain.handle(IpcChannels.PlaybackGetStatus, (): PlaybackStatus => toPlaybackStatus());
   ipcMain.handle(IpcChannels.PlaybackPlayLocalFile, async (_event, request: unknown): Promise<PlaybackStatus> => {
+    clearActiveMediaPlayback();
     try {
       await getAudioSession().playLocalFile(normalizePlayRequest(request));
       savePlaybackMemoryNow();
@@ -538,6 +681,7 @@ export const registerPlaybackIpc = (): void => {
     }
 
     const item = request.item;
+    clearActiveMediaPlayback();
     if (item.mediaType === 'streaming' && item.provider === 'spotify') {
       throw new Error('Spotify playback uses the official Web Playback SDK and must not enter the native audio session.');
     }
@@ -561,6 +705,7 @@ export const registerPlaybackIpc = (): void => {
       if (item.mediaType === 'remote') {
         getRemoteSourceService().setPlaybackActive(true);
       }
+      setActiveMediaPlayback(request);
       void syncSmtcStatus();
       return status;
     } catch (error) {
@@ -590,6 +735,7 @@ export const registerPlaybackIpc = (): void => {
         if (item.mediaType === 'remote') {
           getRemoteSourceService().setPlaybackActive(true);
         }
+        setActiveMediaPlayback(request);
         void syncSmtcStatus();
         return status;
       } catch (retryError) {
@@ -607,6 +753,10 @@ export const registerPlaybackIpc = (): void => {
       void syncSmtcStatus();
       return toPlaybackStatus();
     } catch (error) {
+      if (error instanceof Error && beginActiveMediaExpiredUrlRecovery(error, getAudioSession().getStatus())) {
+        return toPlaybackStatus();
+      }
+
       reportPlaybackAudioError(error, 'playback-resume-ipc');
       throw error;
     }
@@ -618,6 +768,7 @@ export const registerPlaybackIpc = (): void => {
     return toPlaybackStatus();
   });
   ipcMain.handle(IpcChannels.PlaybackStop, (): PlaybackStatus => {
+    clearActiveMediaPlayback();
     getAudioSession().stop();
     getRemoteSourceService().setPlaybackActive(false);
     getPlaybackMemoryStore().clear();

--- a/src/main/library/remote/RemoteBackgroundJobQueue.ts
+++ b/src/main/library/remote/RemoteBackgroundJobQueue.ts
@@ -7,7 +7,7 @@ import type {
 } from '../../../shared/types/remoteSources';
 import { getLyricsService } from '../../lyrics/LyricsService';
 import { getMvService } from '../../mv/MvService';
-import { CoverService } from '../CoverService';
+import type { CoverService } from '../CoverService';
 import type { FieldSources, MetadataStatus, ParsedTrackMetadata } from '../libraryTypes';
 import type { RemoteLibraryStore } from './RemoteLibraryStore';
 import type { RemoteSourceAdapter, RemoteTrackWrite } from './remoteTypes';
@@ -268,7 +268,7 @@ export class RemoteBackgroundJobQueue {
 
     for (const kind of jobKinds) {
       const pending = this.pendingByKind[kind];
-      while (true) {
+      while (pending.length > 0) {
         const index = pending.findIndex((job) => this.canStart(job));
         if (index < 0) {
           break;

--- a/src/renderer/app/AppLayout.test.tsx
+++ b/src/renderer/app/AppLayout.test.tsx
@@ -397,6 +397,68 @@ describe('AppLayout standalone routes', () => {
     await waitFor(() => expect(openAudioCrashReport).toHaveBeenCalledTimes(1));
   });
 
+  it('clears transient audio error notices after playback recovers', async () => {
+    let audioStatusHandler: ((status: { error: string | null; state: string }) => void) | undefined;
+    const audioOnStatus = vi.fn((handler) => {
+      audioStatusHandler = handler as typeof audioStatusHandler;
+      return vi.fn();
+    });
+
+    window.echo = {
+      app: {
+        getSettings: vi.fn().mockResolvedValue({ lyricsPlayerBarDrawerEnabled: false, smtcEnabled: true }),
+      },
+      playback: {
+        getStatus: vi.fn().mockResolvedValue({
+          state: 'idle',
+          currentTrackId: null,
+          positionMs: 0,
+          durationMs: 0,
+          filePath: null,
+        }),
+      },
+      audio: {
+        getStatus: vi.fn().mockResolvedValue({
+          state: 'idle',
+          currentTrackId: null,
+          currentFilePath: null,
+          positionSeconds: 0,
+          durationSeconds: 0,
+          error: null,
+        }),
+        onStatus: audioOnStatus,
+      },
+      diagnostics: {
+        getLastCrashSummary: vi.fn().mockResolvedValue(null),
+        openAudioCrashReport: vi.fn().mockResolvedValue('D:\\ECHO\\audio-crash-report.md'),
+      },
+      library: {
+        getTrack: vi.fn().mockResolvedValue(null),
+        getLikedTrackIds: vi.fn().mockResolvedValue({}),
+      },
+    } as unknown as Window['echo'];
+
+    render(
+      <AppProviders>
+        <AppLayout routes={routes} />
+      </AppProviders>,
+    );
+
+    await waitFor(() => expect(audioStatusHandler).toBeTruthy());
+    audioStatusHandler?.({
+      state: 'error',
+      error: 'echo-audio-host timeout_waiting_for_ready; mode="asio"',
+    });
+    await waitFor(() => expect(screen.getByRole('alert')).toBeTruthy());
+
+    audioStatusHandler?.({
+      state: 'playing',
+      error: null,
+    });
+
+    await waitFor(() => expect(screen.queryByRole('alert')).toBeNull());
+  });
+
   it('auto-dismisses upper-left audio error notices after five seconds', async () => {
     let audioStatusHandler: ((status: { error: string | null; state: string }) => void) | undefined;
     const audioOnStatus = vi.fn((handler) => {

--- a/src/renderer/app/AppLayout.tsx
+++ b/src/renderer/app/AppLayout.tsx
@@ -317,6 +317,24 @@ export const AppLayout = ({ routes }: AppLayoutProps): JSX.Element => {
   }, [playbackStatusSnapshot.audioStatus?.error, playbackStatusSnapshot.error]);
 
   useEffect(() => {
+    const rawError = playbackStatusSnapshot.audioStatus?.error ?? playbackStatusSnapshot.error;
+    const latestState = playbackStatusSnapshot.audioStatus?.state ?? playbackStatusSnapshot.playbackStatus?.state ?? null;
+
+    if (rawError || !audioErrorNotice || latestState === 'error') {
+      return;
+    }
+
+    lastAudioErrorRef.current = null;
+    setAudioErrorNotice(null);
+  }, [
+    audioErrorNotice,
+    playbackStatusSnapshot.audioStatus?.error,
+    playbackStatusSnapshot.audioStatus?.state,
+    playbackStatusSnapshot.error,
+    playbackStatusSnapshot.playbackStatus?.state,
+  ]);
+
+  useEffect(() => {
     if (!audioErrorNotice) {
       return undefined;
     }

--- a/src/renderer/components/player/PlayerBar.test.tsx
+++ b/src/renderer/components/player/PlayerBar.test.tsx
@@ -1667,6 +1667,173 @@ describe('PlayerBar', () => {
     expect(Number(slider.value)).toBeGreaterThanOrEqual(12);
   });
 
+  it('keeps high-speed progress from jumping backward on a brief same-track stale audio status', async () => {
+    const performanceNow = vi.spyOn(performance, 'now').mockReturnValue(0);
+    const track = makeTrack(1);
+    const statusHandlers: Array<(status: AudioStatus) => void> = [];
+    const initialStatus = { ...audioStatus(track), playbackRate: 2, positionSeconds: 12 };
+
+    window.echo = {
+      playback: {
+        getStatus: vi.fn().mockResolvedValue({
+          state: 'playing',
+          currentTrackId: track.id,
+          positionMs: 12000,
+          durationMs: track.duration * 1000,
+          filePath: track.path,
+        }),
+        playLocalFile: vi.fn(),
+        play: vi.fn(),
+        pause: vi.fn(),
+        stop: vi.fn(),
+        seek: vi.fn(),
+        openLocalAudioFile: vi.fn(),
+      },
+      audio: {
+        getStatus: vi.fn().mockResolvedValue(initialStatus),
+        onStatus: vi.fn((handler) => {
+          statusHandlers[0] = handler;
+          return () => {
+            statusHandlers.length = 0;
+          };
+        }),
+        listDevices: vi.fn(),
+        setOutput: vi.fn(),
+      },
+      eq: {
+        getState: vi.fn().mockResolvedValue(eqState()),
+        setEnabled: vi.fn().mockResolvedValue(eqState()),
+        setBandGain: vi.fn().mockResolvedValue(eqState()),
+        setPreamp: vi.fn().mockResolvedValue(eqState()),
+        setPreset: vi.fn().mockResolvedValue(eqState()),
+        reset: vi.fn().mockResolvedValue(eqState()),
+        listPresets: vi.fn().mockResolvedValue([]),
+        savePreset: vi.fn(),
+        deletePreset: vi.fn().mockResolvedValue([]),
+      },
+      app: {
+        getVersion: vi.fn(),
+        minimize: vi.fn(),
+        toggleMaximize: vi.fn(),
+        close: vi.fn(),
+      },
+      library: {
+        getTracks: vi.fn(),
+        getAlbums: vi.fn(),
+        getAlbumTracks: vi.fn(),
+        getSummary: vi.fn(),
+        chooseFolder: vi.fn(),
+        addFolder: vi.fn(),
+        getFolders: vi.fn(),
+        removeFolder: vi.fn(),
+        scanFolder: vi.fn(),
+        getScanStatus: vi.fn(),
+        cancelScan: vi.fn(),
+        getDiagnostics: vi.fn(),
+      },
+    } as unknown as Window['echo'];
+
+    render(
+      <PlaybackQueueProvider>
+        <QueueSeed tracks={[track]} />
+      </PlaybackQueueProvider>,
+    );
+
+    await screen.findByText('Song 1');
+    const slider = screen.getByRole('slider', { name: 'Seek position' }) as HTMLInputElement;
+    await waitFor(() => expect(Number(slider.value)).toBeGreaterThanOrEqual(12));
+
+    performanceNow.mockReturnValue(900);
+    act(() => {
+      statusHandlers[0]?.({ ...audioStatus(track), playbackRate: 2, positionSeconds: 12.2 });
+    });
+
+    expect(Number(slider.value)).toBeGreaterThanOrEqual(13.7);
+  });
+
+  it('rebases progress smoothly when playback speed changes with a stale source position', async () => {
+    const performanceNow = vi.spyOn(performance, 'now').mockReturnValue(0);
+    const track = makeTrack(1);
+    const statusHandlers: Array<(status: AudioStatus) => void> = [];
+
+    window.echo = {
+      playback: {
+        getStatus: vi.fn().mockResolvedValue({
+          state: 'playing',
+          currentTrackId: track.id,
+          positionMs: 12000,
+          durationMs: track.duration * 1000,
+          filePath: track.path,
+        }),
+        playLocalFile: vi.fn(),
+        play: vi.fn(),
+        pause: vi.fn(),
+        stop: vi.fn(),
+        seek: vi.fn(),
+        openLocalAudioFile: vi.fn(),
+      },
+      audio: {
+        getStatus: vi.fn().mockResolvedValue({ ...audioStatus(track), playbackRate: 1, positionSeconds: 12 }),
+        onStatus: vi.fn((handler) => {
+          statusHandlers[0] = handler;
+          return () => {
+            statusHandlers.length = 0;
+          };
+        }),
+        listDevices: vi.fn(),
+        setOutput: vi.fn(),
+      },
+      eq: {
+        getState: vi.fn().mockResolvedValue(eqState()),
+        setEnabled: vi.fn().mockResolvedValue(eqState()),
+        setBandGain: vi.fn().mockResolvedValue(eqState()),
+        setPreamp: vi.fn().mockResolvedValue(eqState()),
+        setPreset: vi.fn().mockResolvedValue(eqState()),
+        reset: vi.fn().mockResolvedValue(eqState()),
+        listPresets: vi.fn().mockResolvedValue([]),
+        savePreset: vi.fn(),
+        deletePreset: vi.fn().mockResolvedValue([]),
+      },
+      app: {
+        getVersion: vi.fn(),
+        minimize: vi.fn(),
+        toggleMaximize: vi.fn(),
+        close: vi.fn(),
+      },
+      library: {
+        getTracks: vi.fn(),
+        getAlbums: vi.fn(),
+        getAlbumTracks: vi.fn(),
+        getSummary: vi.fn(),
+        chooseFolder: vi.fn(),
+        addFolder: vi.fn(),
+        getFolders: vi.fn(),
+        removeFolder: vi.fn(),
+        scanFolder: vi.fn(),
+        getScanStatus: vi.fn(),
+        cancelScan: vi.fn(),
+        getDiagnostics: vi.fn(),
+      },
+    } as unknown as Window['echo'];
+
+    render(
+      <PlaybackQueueProvider>
+        <QueueSeed tracks={[track]} />
+      </PlaybackQueueProvider>,
+    );
+
+    await screen.findByText('Song 1');
+    const slider = screen.getByRole('slider', { name: 'Seek position' }) as HTMLInputElement;
+    await waitFor(() => expect(Number(slider.value)).toBeGreaterThanOrEqual(12));
+
+    performanceNow.mockReturnValue(2000);
+    act(() => {
+      statusHandlers[0]?.({ ...audioStatus(track), playbackRate: 2, positionSeconds: 12.4 });
+    });
+
+    expect(Number(slider.value)).toBeGreaterThanOrEqual(13.9);
+  });
+
   it('broadcasts the requested seek target when streaming seek returns stale status', async () => {
     const track = makeTrack(1, {
       id: 'streaming:qqmusic:song-1',

--- a/src/renderer/components/player/PlayerBar.tsx
+++ b/src/renderer/components/player/PlayerBar.tsx
@@ -33,6 +33,7 @@ const playbackSeekedEvent = 'playback:seeked';
 const maxInterpolatedStatusGapSeconds = 1.6;
 const maxStaleStatusRegressionSeconds = 2.5;
 const seekAnchorMaxAgeSeconds = 3;
+const playbackRateChangeDiscontinuitySeconds = 0.35;
 const isStreamingProviderName = (provider: string | null | undefined): provider is StreamingProviderName =>
   streamingProviderNames.includes(provider as StreamingProviderName);
 const isVerifiedAudioAnalysisBpm = (track: { bpm?: number | null; bpmConfidence?: number | null; analysisStatus?: string | null; fieldSources?: Record<string, string> } | null): boolean =>
@@ -385,17 +386,23 @@ export const PlayerBar = ({ onOpenAudioSettings }: PlayerBarProps): JSX.Element 
     }
 
     if (!seekAnchorRef.current && samePlayback && !stateChanged && state === 'playing') {
-      const elapsedSeconds = Math.max(0, (now - previous.updatedAtMs) / 1000) * previous.playbackRate;
-      const estimatedPositionSeconds = Math.min(previous.positionSeconds + elapsedSeconds, durationLimit);
+      const wallElapsedSeconds = Math.max(0, (now - previous.updatedAtMs) / 1000);
+      const mediaElapsedSeconds = wallElapsedSeconds * previous.playbackRate;
+      const estimatedPositionSeconds = Math.min(previous.positionSeconds + mediaElapsedSeconds, durationLimit);
       const sourceJumpedBackward = boundedSourcePosition + 1 < previous.sourcePositionSeconds;
       const sourceCaughtUp = boundedSourcePosition + 0.35 >= estimatedPositionSeconds;
       const sourceJumpedForward = boundedSourcePosition > estimatedPositionSeconds + 0.35;
-      const canBridgeSourceLag = elapsedSeconds <= maxInterpolatedStatusGapSeconds;
+      const canBridgeSourceLag = wallElapsedSeconds <= maxInterpolatedStatusGapSeconds;
+      const playbackRateChanged = Math.abs(previous.playbackRate - playbackRate) > 0.001;
+      const rateChangeSourceDiscontinuity =
+        playbackRateChanged && Math.abs(boundedSourcePosition - estimatedPositionSeconds) > playbackRateChangeDiscontinuitySeconds;
       const staleRegressionSeconds = previous.positionSeconds - boundedSourcePosition;
       const canIgnoreStaleRegression =
         canBridgeSourceLag && staleRegressionSeconds > 0.35 && staleRegressionSeconds <= maxStaleStatusRegressionSeconds;
 
-      if (canIgnoreStaleRegression) {
+      if (rateChangeSourceDiscontinuity) {
+        nextPositionSeconds = estimatedPositionSeconds;
+      } else if (canIgnoreStaleRegression) {
         nextPositionSeconds = estimatedPositionSeconds;
       } else if (canBridgeSourceLag && !sourceJumpedBackward && !sourceCaughtUp && !sourceJumpedForward && estimatedPositionSeconds > boundedSourcePosition) {
         nextPositionSeconds = estimatedPositionSeconds;

--- a/src/renderer/pages/LyricsPage.test.tsx
+++ b/src/renderer/pages/LyricsPage.test.tsx
@@ -584,6 +584,67 @@ describe("LyricsPage", () => {
     ).toContain("Second line");
   });
 
+  it("keeps high-speed active lyrics from jumping backward on a brief same-track stale audio status", async () => {
+    const performanceNow = vi.spyOn(performance, "now").mockReturnValue(0);
+    const track = makeTrack();
+    const { emitAudioStatus } = mockEcho(track, 10.4);
+    window.echo.audio.getStatus = vi
+      .fn()
+      .mockResolvedValue({ ...makeAudioStatus(track, 10.4), playbackRate: 2 });
+
+    const { container } = render(
+      <PlaybackQueueProvider>
+        <QueueSeed track={track}>
+          <LyricsPage initialLyrics={lyrics} />
+        </QueueSeed>
+      </PlaybackQueueProvider>,
+    );
+
+    await waitFor(() =>
+      expect(
+        container.querySelector('.lyrics-line[data-active="true"]')?.textContent,
+      ).toContain("Second line"),
+    );
+
+    performanceNow.mockReturnValue(900);
+    act(() => {
+      emitAudioStatus({ ...makeAudioStatus(track, 8.9), playbackRate: 2 });
+    });
+
+    expect(
+      container.querySelector('.lyrics-line[data-active="true"]')?.textContent,
+    ).toContain("Second line");
+  });
+
+  it("rebases active lyrics smoothly when playback speed changes with a stale source position", async () => {
+    const performanceNow = vi.spyOn(performance, "now").mockReturnValue(0);
+    const track = makeTrack();
+    const { emitAudioStatus } = mockEcho(track, 10.4);
+
+    const { container } = render(
+      <PlaybackQueueProvider>
+        <QueueSeed track={track}>
+          <LyricsPage initialLyrics={lyrics} />
+        </QueueSeed>
+      </PlaybackQueueProvider>,
+    );
+
+    await waitFor(() =>
+      expect(
+        container.querySelector('.lyrics-line[data-active="true"]')?.textContent,
+      ).toContain("Second line"),
+    );
+
+    performanceNow.mockReturnValue(2000);
+    act(() => {
+      emitAudioStatus({ ...makeAudioStatus(track, 8.9), playbackRate: 2 });
+    });
+
+    expect(
+      container.querySelector('.lyrics-line[data-active="true"]')?.textContent,
+    ).toContain("Second line");
+  });
+
   it("updates active lyrics immediately when playback seek commits from the progress bar", async () => {
     const track = makeTrack();
     const { emitAudioStatus } = mockEcho(track, 0);
@@ -957,10 +1018,15 @@ describe("LyricsPage", () => {
   it("uses a high resolution network cover for cover-following lyrics background when available", async () => {
     const track = makeTrack({ coverId: "cover 1" });
     mockEcho(track, 0, { lyricsBackgroundMode: "cover" });
-    window.echo.library.resolveLyricsBackgroundCover = vi.fn().mockResolvedValue({
-      coverUrl: "echo-image://remote/https%3A%2F%2Fp.music.126.net%2Fcover.jpg%3Fparam%3D2000y2000",
-      provider: "netease-cloud-music",
-      confidence: 0.96,
+    let resolveNetworkCover!: (value: {
+      coverUrl: string;
+      provider: string;
+      confidence: number;
+    }) => void;
+    window.echo.library.resolveLyricsBackgroundCover = vi.fn().mockImplementation(() => {
+      return new Promise((resolve) => {
+        resolveNetworkCover = resolve;
+      });
     });
 
     const { container } = render(
@@ -977,6 +1043,11 @@ describe("LyricsPage", () => {
     expect(page.style.getPropertyValue("--lyrics-cover")).toBe(
       'url("echo-cover://original/cover%201")',
     );
+    resolveNetworkCover({
+      coverUrl: "echo-image://remote/https%3A%2F%2Fp.music.126.net%2Fcover.jpg%3Fparam%3D2000y2000",
+      provider: "netease-cloud-music",
+      confidence: 0.96,
+    });
     await waitFor(() =>
       expect(page.style.getPropertyValue("--lyrics-cover")).toBe(
         'url("echo-image://remote/https%3A%2F%2Fp.music.126.net%2Fcover.jpg%3Fparam%3D2000y2000")',
@@ -1716,6 +1787,7 @@ describe("LyricsPage", () => {
       "echo-wallpaper://lyrics/custom",
     );
     expect(page.style.getPropertyValue("--lyrics-cover-opacity")).toBe("0.66");
+    expect(page.style.getPropertyValue("--lyrics-background-surface-alpha")).toBe("0.66");
     expect(page.style.getPropertyValue("--lyrics-cover-blur")).toBe("18px");
     expect(page.style.getPropertyValue("--lyrics-cover-brightness")).toBe(
       "120%",
@@ -1821,6 +1893,7 @@ describe("LyricsPage", () => {
     expect(page.style.getPropertyValue("--lyrics-color")).toBe("#FFFFFF");
     expect(page.style.getPropertyValue("--lyrics-smart-primary-color")).toMatch(/^rgb\(/);
     expect(page.style.getPropertyValue("--lyrics-cover-opacity")).toBe("0.24");
+    expect(page.style.getPropertyValue("--lyrics-background-surface-alpha")).toBe("0.24");
     expect(page.style.getPropertyValue("--lyrics-cover-blur")).toBe("4px");
     expect(page.style.getPropertyValue("--lyrics-cover-brightness")).toBe(
       "72%",

--- a/src/renderer/pages/LyricsPage.tsx
+++ b/src/renderer/pages/LyricsPage.tsx
@@ -86,6 +86,7 @@ const lyricsCandidateSourceMemoryKey = "echo:lyrics:candidate-source";
 const maxInterpolatedStatusGapSeconds = 1.6;
 const maxStaleStatusRegressionSeconds = 2.5;
 const seekAnchorMaxAgeSeconds = 3;
+const playbackRateChangeDiscontinuitySeconds = 0.35;
 const albumNavigationTransitionMs = 180;
 
 const fallbackLyricsDisplaySettings: LyricsDisplaySettings = {
@@ -581,17 +582,23 @@ const useLyricsDisplayPosition = (
     }
 
     if (!seekAnchorRef.current && samePlayback && !stateChanged && state === "playing") {
-      const elapsedSeconds = Math.max(0, (now - previous.updatedAtMs) / 1000) * previous.playbackRate;
-      const estimatedPositionSeconds = Math.min(previous.positionSeconds + elapsedSeconds, durationLimit);
+      const wallElapsedSeconds = Math.max(0, (now - previous.updatedAtMs) / 1000);
+      const mediaElapsedSeconds = wallElapsedSeconds * previous.playbackRate;
+      const estimatedPositionSeconds = Math.min(previous.positionSeconds + mediaElapsedSeconds, durationLimit);
       const sourceJumpedBackward = boundedSourcePosition + 1 < previous.sourcePositionSeconds;
       const sourceCaughtUp = boundedSourcePosition + 0.35 >= estimatedPositionSeconds;
       const sourceJumpedForward = boundedSourcePosition > estimatedPositionSeconds + 0.35;
-      const canBridgeSourceLag = elapsedSeconds <= maxInterpolatedStatusGapSeconds;
+      const canBridgeSourceLag = wallElapsedSeconds <= maxInterpolatedStatusGapSeconds;
+      const playbackRateChanged = Math.abs(previous.playbackRate - playbackRate) > 0.001;
+      const rateChangeSourceDiscontinuity =
+        playbackRateChanged && Math.abs(boundedSourcePosition - estimatedPositionSeconds) > playbackRateChangeDiscontinuitySeconds;
       const staleRegressionSeconds = previous.positionSeconds - boundedSourcePosition;
       const canIgnoreStaleRegression =
         canBridgeSourceLag && staleRegressionSeconds > 0.35 && staleRegressionSeconds <= maxStaleStatusRegressionSeconds;
 
-      if (canIgnoreStaleRegression) {
+      if (rateChangeSourceDiscontinuity) {
+        nextPositionSeconds = estimatedPositionSeconds;
+      } else if (canIgnoreStaleRegression) {
         nextPositionSeconds = estimatedPositionSeconds;
       } else if (canBridgeSourceLag && !sourceJumpedBackward && !sourceCaughtUp && !sourceJumpedForward && estimatedPositionSeconds > boundedSourcePosition) {
         nextPositionSeconds = estimatedPositionSeconds;
@@ -805,6 +812,9 @@ export const LyricsPage = ({ initialLyrics }: LyricsPageProps): JSX.Element => {
         ).toFixed(2),
         "--lyrics-color": lyricsDisplaySettings.lyricsColor,
         "--lyrics-cover-opacity": (
+          lyricsDisplaySettings.lyricsCoverOpacityPercent / 100
+        ).toFixed(2),
+        "--lyrics-background-surface-alpha": (
           lyricsDisplaySettings.lyricsCoverOpacityPercent / 100
         ).toFixed(2),
         "--lyrics-cover-blur": `${lyricsDisplaySettings.lyricsCoverBlurPx}px`,

--- a/src/renderer/stores/PlaybackQueueProvider.test.tsx
+++ b/src/renderer/stores/PlaybackQueueProvider.test.tsx
@@ -587,6 +587,97 @@ describe('PlaybackQueueProvider playback history session', () => {
     finishSecondPlay();
     await waitFor(() => expect(screen.getByLabelText('visual-state').textContent).toBe(''));
   });
+
+  it('does not let a superseded ASIO start failure overwrite the active track', async () => {
+    const first = makeTrack(1);
+    const second = makeTrack(2);
+    const firstPlayback = { reject: null as ((error: Error) => void) | null };
+    const playLocalFile = vi
+      .fn()
+      .mockImplementationOnce(() =>
+        new Promise((_resolve, reject) => {
+          firstPlayback.reject = reject;
+        }),
+      )
+      .mockImplementationOnce((request: { trackId: string; filePath: string }) =>
+        Promise.resolve({
+          state: 'playing',
+          currentTrackId: request.trackId,
+          positionMs: 0,
+          durationMs: second.duration * 1000,
+          filePath: request.filePath,
+        }),
+      );
+
+    window.echo = {
+      playback: {
+        playLocalFile,
+        getStatus: vi.fn().mockResolvedValue({
+          state: 'playing',
+          currentTrackId: second.id,
+          positionMs: 0,
+          durationMs: second.duration * 1000,
+          filePath: second.path,
+        }),
+      },
+      audio: {
+        getStatus: vi.fn().mockResolvedValue({
+          state: 'playing',
+          currentTrackId: second.id,
+          currentFilePath: second.path,
+          positionSeconds: 0,
+          durationSeconds: second.duration,
+          error: null,
+        }),
+      },
+    } as unknown as Window['echo'];
+
+    const SupersededFailureProbe = (): JSX.Element => {
+      const queue = usePlaybackQueue();
+      const status = useSharedPlaybackStatus();
+      const didStartRef = useRef(false);
+
+      useEffect(() => {
+        if (didStartRef.current) {
+          return;
+        }
+
+        didStartRef.current = true;
+        queue.replaceQueue([first, second]);
+        void queue.playTrack(first).catch(() => undefined);
+      }, [queue]);
+
+      return (
+        <div>
+          <output aria-label="queue-track">{queue.currentTrackId ?? ''}</output>
+          <output aria-label="shared-track">{status.playbackStatus?.currentTrackId ?? ''}</output>
+          <output aria-label="shared-error">{status.error ?? ''}</output>
+          <button type="button" onClick={() => void queue.playNext()}>
+            next
+          </button>
+        </div>
+      );
+    };
+
+    render(
+      <PlaybackQueueProvider>
+        <SupersededFailureProbe />
+      </PlaybackQueueProvider>,
+    );
+
+    await waitFor(() => expect(screen.getByLabelText('queue-track').textContent).toBe(first.id));
+    fireEvent.click(screen.getByRole('button', { name: 'next' }));
+    await waitFor(() => expect(screen.getByLabelText('queue-track').textContent).toBe(second.id));
+
+    const rejectFirstPlay = firstPlayback.reject;
+    if (!rejectFirstPlay) {
+      throw new Error('first playback promise was not captured');
+    }
+    rejectFirstPlay(new Error('echo-audio-host timeout_waiting_for_ready; mode="asio"'));
+
+    await waitFor(() => expect(screen.getByLabelText('shared-track').textContent).toBe(second.id));
+    expect(screen.getByLabelText('shared-error').textContent).toBe('');
+  });
 });
 
 describe('PlaybackQueueProvider playback modes', () => {

--- a/src/renderer/stores/PlaybackQueueProvider.tsx
+++ b/src/renderer/stores/PlaybackQueueProvider.tsx
@@ -705,6 +705,10 @@ export const PlaybackQueueProvider = ({ children }: PropsWithChildren): JSX.Elem
                   });
             })();
       } catch (error) {
+        if (playRequestTokenRef.current !== requestToken) {
+          throw new Error('audio_session_run_cancelled');
+        }
+
         setPlaybackStatusSnapshot({
           playbackStatus: statusForPlaybackFailure(item.track),
           error: error instanceof Error ? error.message : String(error),

--- a/src/renderer/styles/lyrics.css
+++ b/src/renderer/styles/lyrics.css
@@ -13,6 +13,7 @@
   --lyrics-color: #314054;
   --lyrics-readable-color: color-mix(in srgb, var(--lyrics-color) 24%, #1b2a3d 76%);
   --lyrics-cover-opacity: 1;
+  --lyrics-background-surface-alpha: 1;
   --lyrics-cover-blur: 10px;
   --lyrics-cover-brightness: 100%;
   --lyrics-background-scale: 1;
@@ -83,6 +84,7 @@
       rgba(211, 222, 234, 0.24)
     );
   content: "";
+  opacity: var(--lyrics-background-surface-alpha);
 }
 
 .lyrics-page[data-background="theme"] .lyrics-backdrop::after {
@@ -93,7 +95,7 @@
   background-image: var(--lyrics-cover);
   filter: blur(var(--lyrics-cover-blur))
     brightness(calc(var(--lyrics-cover-brightness) * 0.82)) saturate(0.94);
-  opacity: var(--lyrics-cover-opacity);
+  opacity: 1;
 }
 
 .lyrics-page[data-background="customWallpaper"] .lyrics-backdrop {
@@ -114,7 +116,7 @@
   background-image: var(--lyrics-wallpaper);
   filter: blur(var(--lyrics-cover-blur))
     brightness(calc(var(--lyrics-cover-brightness) * 0.82)) saturate(0.92);
-  opacity: var(--lyrics-cover-opacity);
+  opacity: 1;
 }
 
 html[data-theme="dark"] .page-surface:has(.lyrics-page) {
@@ -142,7 +144,7 @@ html[data-theme="dark"] .lyrics-backdrop {
 }
 
 html[data-theme="dark"] .lyrics-backdrop::before {
-  opacity: 0;
+  background: var(--theme-panel-bg-strong);
 }
 
 html[data-theme="dark"] .lyrics-backdrop::after {
@@ -153,7 +155,7 @@ html[data-theme="dark"] .lyrics-backdrop::after {
 html[data-theme="dark"] .lyrics-page[data-background="cover"] .lyrics-backdrop::after {
   filter: blur(var(--lyrics-cover-blur))
     brightness(var(--lyrics-cover-brightness)) saturate(1.08);
-  opacity: var(--lyrics-cover-opacity);
+  opacity: 1;
 }
 
 html[data-theme="dark"] .lyrics-page[data-background="customWallpaper"] .lyrics-backdrop {


### PR DESCRIPTION
## Summary
- Sync the remaining branch fixes onto the current `main` branch
- Preserve `main`'s latest merged playback-speed and lyrics-matching work
- Ignore local FFmpeg binaries so GitHub large-file rejects do not recur

## Notes
- This PR is based on latest `origin/main` (`e996768`).
- The playback speed progress fix was already merged into `main` via PR #48, so this branch now contains only the 2 remaining commits.
- Local uncommitted database recovery changes were intentionally left out of this sync branch.

## Validation
- `npm test -- src/main/ipc/playbackIpc.test.ts src/main/audio/AudioCore.test.ts src/renderer/components/player/PlayerBar.test.tsx src/renderer/app/AppLayout.test.tsx src/renderer/pages/LyricsPage.test.tsx src/renderer/stores/PlaybackQueueProvider.test.tsx` passed: 6 files, 331 tests
- Verified branch is ahead of `origin/main` by 2 commits and not behind
- Verified `electron-app/tools/ffmpeg.exe` is ignored and no longer tracked in `HEAD`
- Verified no newly introduced blob over 100 MB exists in `origin/main..HEAD`