### PR TITLE
feat: 支持竖排歌词与桌面歌词播放控制

### DIFF
--- a/src/main/app/appSettings.test.ts
+++ b/src/main/app/appSettings.test.ts
@@ -149,6 +149,7 @@ describe('app settings normalization', () => {
     expect(settings.lyricsWordHighlightClarityPercent).toBe(70);
     expect(settings.lyricsFontSizePx).toBe(40);
     expect(settings.lyricsSecondaryFontSizePx).toBe(22);
+    expect(settings.lyricsTextDirection).toBe('horizontal');
     expect(settings.lyricsLineSpacingPercent).toBe(110);
     expect(settings.lyricsLineMaxChars).toBe(0);
     expect(settings.lyricsContextOpacityPercent).toBe(49);
@@ -164,6 +165,7 @@ describe('app settings normalization', () => {
     expect(settings.desktopLyricsFontFamily).toBe('Microsoft YaHei');
     expect(settings.desktopLyricsFontFilePath).toBeNull();
     expect(settings.desktopLyricsColorMode).toBe('theme');
+    expect(settings.desktopLyricsTextDirection).toBe('horizontal');
     expect(settings.desktopLyricsRomanizationEnabled).toBe(true);
     expect(settings.desktopLyricsTranslationEnabled).toBe(true);
     expect(settings.miniPlayerEnabled).toBe(false);
@@ -1417,6 +1419,7 @@ describe('app settings normalization', () => {
         lyricsWordHighlightEnabled: false,
         lyricsWordHighlightClarityPercent: 999,
         lyricsFontSizePx: 999,
+        lyricsTextDirection: 'sideways' as never,
         lyricsLineSpacingPercent: 999,
         lyricsLineMaxChars: 999,
         lyricsContextOpacityPercent: 1000,
@@ -1430,6 +1433,7 @@ describe('app settings normalization', () => {
         lyricsCoverBrightnessPercent: 12,
         lyricsBackgroundScalePercent: 999,
         desktopLyricsColorMode: 'neon' as never,
+        desktopLyricsTextDirection: 'sideways' as never,
         desktopLyricsRomanizationEnabled: false,
         desktopLyricsTranslationEnabled: false,
       }),
@@ -1466,6 +1470,7 @@ describe('app settings normalization', () => {
       lyricsWordHighlightEnabled: false,
       lyricsWordHighlightClarityPercent: 100,
       lyricsFontSizePx: 56,
+      lyricsTextDirection: 'horizontal',
       lyricsLineSpacingPercent: 150,
       lyricsLineMaxChars: 80,
       lyricsContextOpacityPercent: 100,
@@ -1479,6 +1484,7 @@ describe('app settings normalization', () => {
       lyricsCoverBrightnessPercent: 40,
       lyricsBackgroundScalePercent: 180,
       desktopLyricsColorMode: 'theme',
+      desktopLyricsTextDirection: 'horizontal',
       desktopLyricsRomanizationEnabled: false,
       desktopLyricsTranslationEnabled: false,
     });
@@ -1487,6 +1493,7 @@ describe('app settings normalization', () => {
     expect(
       normalizeSettings({
         lyricsFontSizePx: 12,
+        lyricsTextDirection: 'vertical',
         lyricsWordHighlightClarityPercent: 20,
         lyricsLineSpacingPercent: 20,
         lyricsLineMaxChars: -1,
@@ -1508,11 +1515,13 @@ describe('app settings normalization', () => {
         lyricsBackgroundScalePercent: 55,
         desktopLyricsColorMode: 'custom',
         desktopLyricsColor: '#ff8a80',
+        desktopLyricsTextDirection: 'vertical',
       }),
     ).toMatchObject({
       lyricsFontSizePx: 22,
       lyricsWordHighlightClarityPercent: 40,
       lyricsLineSpacingPercent: 60,
+      lyricsTextDirection: 'vertical',
       lyricsLineMaxChars: 0,
       lyricsAutoAcceptScore: 0.3,
       lyricsBackfillAutoAcceptScore: 0.3,
@@ -1532,6 +1541,7 @@ describe('app settings normalization', () => {
       lyricsBackgroundScalePercent: 70,
       desktopLyricsColorMode: 'custom',
       desktopLyricsColor: '#FF8A80',
+      desktopLyricsTextDirection: 'vertical',
       lyricsRomanizationEnabled: true,
       lyricsTranslationEnabled: true,
       lyricsWordHighlightEnabled: true,

--- a/src/main/app/appSettings.ts
+++ b/src/main/app/appSettings.ts
@@ -485,6 +485,7 @@ export const defaultSettings: AppSettings = {
   lyricsSecondaryFontSizePx: 22,
   lyricsFontFamily: 'Microsoft YaHei',
   lyricsFontFilePath: null,
+  lyricsTextDirection: 'horizontal',
   lyricsLineSpacingPercent: 110,
   lyricsLineMaxChars: 0,
   lyricsContextOpacityPercent: 49,
@@ -507,6 +508,7 @@ export const defaultSettings: AppSettings = {
   desktopLyricsColor: defaultDesktopLyricsColor,
   desktopLyricsStrokeColor: defaultDesktopLyricsStrokeColor,
   desktopLyricsOpacityPercent: 96,
+  desktopLyricsTextDirection: 'horizontal',
   desktopLyricsRomanizationEnabled: true,
   desktopLyricsTranslationEnabled: true,
   desktopLyricsBounds: null,
@@ -1218,6 +1220,9 @@ const normalizeLyricsBackgroundMode = (value: unknown): LyricsBackgroundMode =>
     ? value
     : defaultSettings.lyricsBackgroundMode;
 
+const normalizeLyricsTextDirection = (value: unknown): AppSettings['lyricsTextDirection'] =>
+  value === 'vertical' || value === 'horizontal' ? value : defaultSettings.lyricsTextDirection ?? 'horizontal';
+
 const normalizeLyricsMiniPlayerColorMode = (value: unknown): LyricsMiniPlayerColorMode =>
   value === 'custom' || value === 'cover' || value === 'default' ? value : defaultSettings.lyricsPlayerBarDrawerColorMode ?? 'default';
 
@@ -1722,6 +1727,7 @@ export const normalizeSettings = (value: unknown): AppSettings => {
       : defaultSettings.lyricsSecondaryFontSizePx,
     lyricsFontFamily: normalizeRequiredText(settings.lyricsFontFamily, defaultSettings.lyricsFontFamily ?? 'Microsoft YaHei'),
     lyricsFontFilePath: normalizeFontPath(settings.lyricsFontFilePath),
+    lyricsTextDirection: normalizeLyricsTextDirection(settings.lyricsTextDirection),
     lyricsLineSpacingPercent: Number.isFinite(lyricsLineSpacingPercent)
       ? Math.round(clamp(lyricsLineSpacingPercent, 60, 150))
       : defaultSettings.lyricsLineSpacingPercent,
@@ -1764,6 +1770,7 @@ export const normalizeSettings = (value: unknown): AppSettings => {
     desktopLyricsOpacityPercent: Number.isFinite(desktopLyricsOpacityPercent)
       ? Math.round(clamp(desktopLyricsOpacityPercent, 35, 100))
       : defaultSettings.desktopLyricsOpacityPercent,
+    desktopLyricsTextDirection: normalizeLyricsTextDirection(settings.desktopLyricsTextDirection),
     desktopLyricsRomanizationEnabled: settings.desktopLyricsRomanizationEnabled !== false,
     desktopLyricsTranslationEnabled: settings.desktopLyricsTranslationEnabled !== false,
     desktopLyricsBounds: normalizeDesktopLyricsBounds(settings.desktopLyricsBounds),

--- a/src/main/app/desktopLyricsWindow.test.ts
+++ b/src/main/app/desktopLyricsWindow.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const mocks = vi.hoisted(() => ({
   settings: {
     desktopLyricsBounds: null as { x: number; y: number; width: number; height: number } | null,
+    desktopLyricsTextDirection: 'horizontal' as 'horizontal' | 'vertical',
   },
   displays: [
     {
@@ -47,6 +48,7 @@ vi.mock('../diagnostics/DevConsoleService', () => ({
 describe('desktop lyrics window bounds', () => {
   beforeEach(() => {
     mocks.settings.desktopLyricsBounds = null;
+    mocks.settings.desktopLyricsTextDirection = 'horizontal';
     mocks.displays = [
       {
         bounds: { x: 0, y: 0, width: 1920, height: 1080 },
@@ -82,6 +84,36 @@ describe('desktop lyrics window bounds', () => {
       y: 846,
       width: 760,
       height: 150,
+    });
+  });
+
+  it('uses a taller default window for vertical desktop lyrics', async () => {
+    mocks.settings.desktopLyricsTextDirection = 'vertical';
+    const { resolveInitialDesktopLyricsBounds } = await import('./desktopLyricsWindow');
+
+    expect(resolveInitialDesktopLyricsBounds()).toEqual({
+      x: 730,
+      y: 356,
+      width: 460,
+      height: 640,
+    });
+  });
+
+  it('expands short saved bounds when restoring vertical desktop lyrics', async () => {
+    mocks.settings.desktopLyricsTextDirection = 'vertical';
+    mocks.settings.desktopLyricsBounds = {
+      x: 480,
+      y: 760,
+      width: 760,
+      height: 150,
+    };
+    const { resolveInitialDesktopLyricsBounds } = await import('./desktopLyricsWindow');
+
+    expect(resolveInitialDesktopLyricsBounds()).toEqual({
+      x: 480,
+      y: 440,
+      width: 760,
+      height: 640,
     });
   });
 });

--- a/src/main/app/desktopLyricsWindow.ts
+++ b/src/main/app/desktopLyricsWindow.ts
@@ -16,9 +16,17 @@ const defaultDesktopLyricsSize = {
   width: 760,
   height: 150,
 } as const;
+const defaultVerticalDesktopLyricsSize = {
+  width: 460,
+  height: 640,
+} as const;
 const desktopLyricsMinimumSize = {
   width: 360,
   height: 84,
+} as const;
+const verticalDesktopLyricsReadableMinimumSize = {
+  width: 360,
+  height: 640,
 } as const;
 const rememberBoundsDebounceMs = 300;
 const forwardedAudioStatusMaxAgeMs = 30_000;
@@ -42,6 +50,7 @@ const toDesktopLyricsSettings = (): DesktopLyricsState['settings'] => {
     desktopLyricsColor: settings.desktopLyricsColor,
     desktopLyricsStrokeColor: settings.desktopLyricsStrokeColor,
     desktopLyricsOpacityPercent: settings.desktopLyricsOpacityPercent,
+    desktopLyricsTextDirection: settings.desktopLyricsTextDirection,
     desktopLyricsRomanizationEnabled: settings.desktopLyricsRomanizationEnabled,
     desktopLyricsTranslationEnabled: settings.desktopLyricsTranslationEnabled,
     desktopLyricsBounds: settings.desktopLyricsBounds,
@@ -101,15 +110,40 @@ const clampBoundsToVisibleArea = (bounds: DesktopLyricsBounds): DesktopLyricsBou
   };
 };
 
+const expandBoundsToReadableVerticalArea = (bounds: DesktopLyricsBounds): DesktopLyricsBounds => {
+  const display = screen.getDisplayMatching(bounds);
+  const area = getDesktopLyricsConstrainArea(display);
+  const width = Math.max(bounds.width, Math.min(verticalDesktopLyricsReadableMinimumSize.width, area.width));
+  const height = Math.max(bounds.height, Math.min(verticalDesktopLyricsReadableMinimumSize.height, area.height));
+
+  return clampBoundsToVisibleArea({
+    x: Math.round(bounds.x - (width - bounds.width) / 2),
+    y: Math.round(bounds.y - (height - bounds.height) / 2),
+    width,
+    height,
+  });
+};
+
+const shouldUseVerticalDesktopLyricsBounds = (): boolean =>
+  getAppSettings().desktopLyricsTextDirection === 'vertical';
+
+const normalizeDesktopLyricsBoundsForTextDirection = (bounds: DesktopLyricsBounds): DesktopLyricsBounds =>
+  shouldUseVerticalDesktopLyricsBounds()
+    ? expandBoundsToReadableVerticalArea(bounds)
+    : clampBoundsToVisibleArea(bounds);
+
 export const resolveInitialDesktopLyricsBounds = (): DesktopLyricsBounds => {
   const savedBounds = getAppSettings().desktopLyricsBounds;
   if (savedBounds && isBoundsVisible(savedBounds)) {
-    return clampBoundsToVisibleArea(savedBounds);
+    return normalizeDesktopLyricsBoundsForTextDirection(savedBounds);
   }
 
   const area = screen.getPrimaryDisplay().workArea;
-  const width = Math.min(defaultDesktopLyricsSize.width, Math.max(desktopLyricsMinimumSize.width, area.width - 48));
-  const height = defaultDesktopLyricsSize.height;
+  const defaultSize = shouldUseVerticalDesktopLyricsBounds()
+    ? defaultVerticalDesktopLyricsSize
+    : defaultDesktopLyricsSize;
+  const width = Math.min(defaultSize.width, Math.max(desktopLyricsMinimumSize.width, area.width - 48));
+  const height = Math.min(defaultSize.height, Math.max(desktopLyricsMinimumSize.height, area.height - 48));
 
   return {
     x: Math.round(area.x + (area.width - width) / 2),
@@ -149,6 +183,24 @@ const scheduleRememberDesktopLyricsBounds = (window: BrowserWindow): void => {
     rememberBoundsTimer = null;
     rememberDesktopLyricsBounds(window);
   }, rememberBoundsDebounceMs);
+};
+
+const applyDesktopLyricsReadableBoundsForTextDirection = (window: BrowserWindow): void => {
+  if (window.isDestroyed() || !shouldUseVerticalDesktopLyricsBounds()) {
+    return;
+  }
+
+  const bounds = window.getBounds();
+  if (
+    bounds.width >= verticalDesktopLyricsReadableMinimumSize.width &&
+    bounds.height >= verticalDesktopLyricsReadableMinimumSize.height
+  ) {
+    return;
+  }
+
+  const nextBounds = expandBoundsToReadableVerticalArea(bounds);
+  window.setBounds(nextBounds);
+  setAppSettings({ desktopLyricsBounds: nextBounds });
 };
 
 const loadDesktopLyricsRenderer = (window: BrowserWindow): void => {
@@ -303,6 +355,10 @@ export const setDesktopLyricsMousePassthrough = (event: IpcMainEvent, passthroug
 
 export const setDesktopLyricsStyle = (patch: DesktopLyricsStylePatch): DesktopLyricsState => {
   setAppSettings(patch);
+  if (desktopLyricsWindow && !desktopLyricsWindow.isDestroyed()) {
+    applyDesktopLyricsReadableBoundsForTextDirection(desktopLyricsWindow);
+    applyDesktopLyricsAlwaysOnTop(desktopLyricsWindow);
+  }
   emitDesktopLyricsStateChanged();
   return getDesktopLyricsState();
 };

--- a/src/main/ipc/desktopLyricsIpc.ts
+++ b/src/main/ipc/desktopLyricsIpc.ts
@@ -34,6 +34,9 @@ const normalizeStylePatch = (value: unknown): DesktopLyricsStylePatch => {
     ...(typeof input.desktopLyricsColor === 'string' ? { desktopLyricsColor: input.desktopLyricsColor } : {}),
     ...(typeof input.desktopLyricsStrokeColor === 'string' ? { desktopLyricsStrokeColor: input.desktopLyricsStrokeColor } : {}),
     ...(input.desktopLyricsOpacityPercent !== undefined ? { desktopLyricsOpacityPercent: Number(input.desktopLyricsOpacityPercent) } : {}),
+    ...(input.desktopLyricsTextDirection === 'horizontal' || input.desktopLyricsTextDirection === 'vertical'
+      ? { desktopLyricsTextDirection: input.desktopLyricsTextDirection }
+      : {}),
     ...(typeof input.desktopLyricsRomanizationEnabled === 'boolean'
       ? { desktopLyricsRomanizationEnabled: input.desktopLyricsRomanizationEnabled }
       : {}),

--- a/src/renderer/components/lyrics/LyricsLine.tsx
+++ b/src/renderer/components/lyrics/LyricsLine.tsx
@@ -1,5 +1,6 @@
 import type { CSSProperties } from 'react';
 import type { LyricLine as LyricLineType, LyricWordTiming } from '../../../shared/types/lyrics';
+import { VerticalText } from './VerticalText';
 
 type LyricsLineProps = {
   line: LyricLineType;
@@ -13,6 +14,7 @@ type LyricsLineProps = {
   showTranslation?: boolean;
   wordHighlightEnabled?: boolean;
   focusDistance?: number;
+  textDirection?: 'horizontal' | 'vertical';
 };
 
 const selectPronunciation = (
@@ -265,6 +267,7 @@ export const LyricsLine = ({
   showTranslation = true,
   wordHighlightEnabled = true,
   focusDistance = 4,
+  textDirection = 'horizontal',
 }: LyricsLineProps): JSX.Element => {
   const density = getLyricDensity(line, showRomanization, showTranslation, preferKanaPronunciation);
   const { text: pronunciation, kind: pronunciationKind } = selectPronunciation(line, preferKanaPronunciation);
@@ -273,6 +276,7 @@ export const LyricsLine = ({
     (showTranslation && line.translation ? 1 : 0);
   const renderableWords = wordHighlightEnabled ? getRenderableLyricWords(line) : null;
   const hasWordHighlight = Boolean(renderableWords);
+  const isVerticalText = textDirection === 'vertical';
 
   return (
     <button
@@ -298,23 +302,41 @@ export const LyricsLine = ({
         }
       }}
     >
-      <span>
-        {hasWordHighlight
-          ? renderableWords?.map((word, index) => (
-            <mark
-              className="lyrics-word"
-              data-word-index={index}
-              data-word-state="future"
-              key={`${word.startMs}-${index}-${word.text}`}
-              style={{ '--lyrics-word-progress': '0' } as CSSProperties}
-            >
-              {word.text}
-            </mark>
-          ))
-          : line.text}
+      <span className="lyrics-line-text">
+        <span className="lyrics-line-primary" aria-label={isVerticalText ? line.text : undefined}>
+          {hasWordHighlight
+            ? renderableWords?.map((word, index) => (
+              <mark
+                className="lyrics-word"
+                data-word-index={index}
+                data-word-state="future"
+                key={`${word.startMs}-${index}-${word.text}`}
+                style={{ '--lyrics-word-progress': '0' } as CSSProperties}
+              >
+                {isVerticalText
+                  ? <VerticalText className="lyrics-upright-character" text={word.text} />
+                  : word.text}
+              </mark>
+            ))
+            : isVerticalText
+              ? <VerticalText className="lyrics-upright-character" text={line.text} />
+              : line.text}
+        </span>
+        {showRomanization && pronunciation ? (
+          <small data-pronunciation={pronunciationKind} aria-label={isVerticalText ? pronunciation : undefined}>
+            {isVerticalText
+              ? <VerticalText className="lyrics-upright-character" text={pronunciation} />
+              : pronunciation}
+          </small>
+        ) : null}
+        {showTranslation && line.translation ? (
+          <em aria-label={isVerticalText ? line.translation : undefined}>
+            {isVerticalText
+              ? <VerticalText className="lyrics-upright-character" text={line.translation} />
+              : line.translation}
+          </em>
+        ) : null}
       </span>
-      {showRomanization && pronunciation ? <small data-pronunciation={pronunciationKind}>{pronunciation}</small> : null}
-      {showTranslation && line.translation ? <em>{line.translation}</em> : null}
     </button>
   );
 };

--- a/src/renderer/components/lyrics/LyricsSettingsDrawer.test.tsx
+++ b/src/renderer/components/lyrics/LyricsSettingsDrawer.test.tsx
@@ -47,6 +47,7 @@ const makeSettings = (overrides: Partial<AppSettings> = {}): AppSettings => ({
   lyricsTranslationEnabled: true,
   lyricsWordHighlightEnabled: true,
   lyricsWordHighlightClarityPercent: 70,
+  lyricsTextDirection: 'horizontal',
   lyricsFontSizePx: 40,
   lyricsSecondaryFontSizePx: 22,
   lyricsLineSpacingPercent: 110,
@@ -61,6 +62,7 @@ const makeSettings = (overrides: Partial<AppSettings> = {}): AppSettings => ({
   lyricsCoverBlurPx: 10,
   lyricsCoverBrightnessPercent: 100,
   lyricsBackgroundScalePercent: 100,
+  desktopLyricsTextDirection: 'horizontal',
   mvEnabledProviders: ['bilibili', 'youtube'],
   mvProviderOrder: ['bilibili', 'youtube'],
   mvAutoSearch: true,
@@ -198,6 +200,7 @@ const makeDesktopLyricsState = (overrides: Partial<DesktopLyricsState> = {}): De
     desktopLyricsOpacityPercent: 96,
     desktopLyricsRomanizationEnabled: true,
     desktopLyricsTranslationEnabled: true,
+    desktopLyricsTextDirection: 'horizontal',
     desktopLyricsBounds: null,
   },
   ...overrides,
@@ -393,6 +396,9 @@ describe('LyricsSettingsDrawer', () => {
     fireEvent.click(screen.getByRole('checkbox', { name: '桌面歌词显示翻译' }));
     await waitFor(() => expect(setStyle).toHaveBeenCalledWith({ desktopLyricsTranslationEnabled: false }));
 
+    fireEvent.click(within(screen.getByLabelText('桌面歌词排版')).getByRole('button', { name: '竖排' }));
+    await waitFor(() => expect(setStyle).toHaveBeenCalledWith({ desktopLyricsTextDirection: 'vertical' }));
+
     const opacitySlider = container.querySelector<HTMLInputElement>('.lyrics-desktop-opacity-control input[type="range"]');
     expect(opacitySlider).toBeTruthy();
     fireEvent.change(opacitySlider as HTMLInputElement, { target: { value: '72' } });
@@ -403,6 +409,24 @@ describe('LyricsSettingsDrawer', () => {
       desktopLyricsFontFamily: 'Microsoft YaHei',
       desktopLyricsFontFilePath: null,
     }));
+  });
+
+  it('updates the main lyrics text direction from the style controls', async () => {
+    const setSettings = vi.fn((patch: Partial<AppSettings>) => Promise.resolve(makeSettings(patch)));
+    window.echo = {
+      app: {
+        getSettings: vi.fn().mockResolvedValue(makeSettings()),
+        setSettings,
+        chooseLyricsWallpaper: vi.fn(),
+      },
+    } as unknown as Window['echo'];
+
+    const { container } = render(<LyricsSettingsDrawer isOpen onClose={vi.fn()} />);
+
+    await waitFor(() => expect(container.querySelector('.lyrics-text-direction-panel')).toBeTruthy());
+    fireEvent.click(within(screen.getByLabelText('歌词排版')).getByRole('button', { name: '竖排' }));
+
+    await waitFor(() => expect(setSettings).toHaveBeenCalledWith({ lyricsTextDirection: 'vertical' }));
   });
 
   it('keeps the desktop lyrics font panel collapsed by default and remembers opening it', async () => {
@@ -506,7 +530,7 @@ describe('LyricsSettingsDrawer', () => {
     expect(thresholdSlider.disabled).toBe(false);
     expect((screen.getByRole('checkbox', { name: /隐藏歌曲信息/ }) as HTMLInputElement).disabled).toBe(false);
     expect((screen.getByRole('checkbox', { name: /关闭MV自动显示歌曲信息/ }) as HTMLInputElement).disabled).toBe(false);
-    expect((screen.getByRole('checkbox', { name: /迷你底栏/ }) as HTMLInputElement).disabled).toBe(false);
+    expect((screen.getByRole('checkbox', { name: /^迷你底栏$/ }) as HTMLInputElement).disabled).toBe(false);
     expect((screen.getByRole('checkbox', { name: /隐藏纯音乐提示/ }) as HTMLInputElement).disabled).toBe(false);
     expect((screen.getByRole('checkbox', { name: /^显示罗马音$/ }) as HTMLInputElement).disabled).toBe(false);
     expect((screen.getByRole('checkbox', { name: /显示中文翻译/ }) as HTMLInputElement).disabled).toBe(false);
@@ -662,12 +686,14 @@ describe('LyricsSettingsDrawer', () => {
     const { container } = render(<LyricsSettingsDrawer isOpen onClose={vi.fn()} />);
 
     await waitFor(() => expect(container.querySelector('.lyrics-style-collapse-button')).toBeTruthy());
-    await waitFor(() => expect(container.querySelector('.lyrics-color-panel')).toBeTruthy());
-    const colorPanel = container.querySelector('.lyrics-color-panel') as HTMLElement;
+    const colorPanel = await waitFor(() => {
+      const palette = screen.getByLabelText('歌词颜色调色盘');
+      const panel = palette.closest('.lyrics-color-panel') as HTMLElement | null;
+      expect(panel).toBeTruthy();
+      return panel!;
+    });
     const colorPreview = colorPanel.querySelector('.lyrics-color-preview') as HTMLElement;
-    const pinkSwatch = Array.from(colorPanel.querySelectorAll<HTMLButtonElement>('.lyrics-color-swatch')).find(
-      (button) => button.style.backgroundColor === 'rgb(255, 138, 128)',
-    ) as HTMLButtonElement;
+    const pinkSwatch = within(colorPanel).getByRole('button', { name: '使用颜色 #FF8A80' });
 
     fireEvent.click(pinkSwatch);
 
@@ -693,10 +719,10 @@ describe('LyricsSettingsDrawer', () => {
     const { container } = render(<LyricsSettingsDrawer isOpen onClose={vi.fn()} />);
 
     await waitFor(() => expect(container.querySelector('.lyrics-style-collapse-button')).toBeTruthy());
-    await waitFor(() => expect(container.querySelector('.lyrics-color-panel')).toBeTruthy());
+    await waitFor(() => expect(screen.getByLabelText('歌词颜色调色盘')).toBeTruthy());
 
     vi.useFakeTimers();
-    const colorPanel = container.querySelector('.lyrics-color-panel') as HTMLElement;
+    const colorPanel = screen.getByLabelText('歌词颜色调色盘').closest('.lyrics-color-panel') as HTMLElement;
     const colorInput = colorPanel.querySelector<HTMLInputElement>('input[type="color"]') as HTMLInputElement;
     const colorPreview = colorPanel.querySelector('.lyrics-color-preview') as HTMLElement;
 
@@ -835,7 +861,7 @@ describe('LyricsSettingsDrawer', () => {
 
     render(<LyricsSettingsDrawer isOpen onClose={vi.fn()} />);
 
-    const toggle = (await screen.findByRole('checkbox', { name: /迷你底栏/ })) as HTMLInputElement;
+    const toggle = (await screen.findByRole('checkbox', { name: /^迷你底栏$/ })) as HTMLInputElement;
     fireEvent.click(toggle);
 
     await waitFor(() => expect(setSettings).toHaveBeenCalledWith({ lyricsPlayerBarDrawerEnabled: true }));
@@ -852,7 +878,7 @@ describe('LyricsSettingsDrawer', () => {
 
     const { unmount } = render(<LyricsSettingsDrawer isOpen onClose={vi.fn()} />);
 
-    await screen.findByRole('checkbox', { name: /迷你底栏/ });
+    await screen.findByRole('checkbox', { name: /^迷你底栏$/ });
     expect(screen.queryByText('底栏透明度')).toBeNull();
     expect(screen.queryByText('底栏颜色')).toBeNull();
 
@@ -1072,7 +1098,7 @@ describe('LyricsSettingsDrawer', () => {
     await waitFor(() => expect(container.querySelector('.lyrics-style-collapse-button')).toBeTruthy());
     expect(container.querySelector('.lyrics-style-collapse-button')?.getAttribute('aria-expanded')).toBe('true');
     expect(container.querySelector('.lyrics-style-range-grid[hidden]')).toBeNull();
-    expect(container.textContent).toContain('包含辅助字号、歌词字号、歌词行距、上下文透明度和歌词颜色。');
+    expect(container.textContent).toContain('包含排版方向、辅助字号、歌词字号、歌词行距、上下文透明度和歌词颜色。');
 
     fireEvent.click(container.querySelector('.lyrics-style-collapse-button') as HTMLButtonElement);
 
@@ -1304,7 +1330,7 @@ describe('LyricsSettingsDrawer', () => {
     const { container } = render(<LyricsSettingsDrawer isOpen onClose={vi.fn()} />);
 
     await waitFor(() => expect(window.echo?.app.getSettings).toHaveBeenCalled());
-    fireEvent.change(screen.getByRole('searchbox', { name: /搜索歌词文本|鎼滅储姝岃瘝鏂囨湰/ }), { target: { value: 'rough query' } });
+    fireEvent.change(screen.getByRole('searchbox', { name: '搜索歌词文本' }), { target: { value: 'rough query' } });
     fireEvent.click(screen.getByRole('button', { name: '搜索' }));
 
     expect(await screen.findByText('Low Match Song')).toBeTruthy();

--- a/src/renderer/components/lyrics/LyricsSettingsDrawer.tsx
+++ b/src/renderer/components/lyrics/LyricsSettingsDrawer.tsx
@@ -15,6 +15,7 @@ import {
   Monitor,
   Music2,
   Palette,
+  Rows3,
   RefreshCw,
   RotateCcw,
   Search,
@@ -99,6 +100,7 @@ type LyricsDrawerSettings = Pick<
   | 'lyricsSecondaryFontSizePx'
   | 'lyricsFontFamily'
   | 'lyricsFontFilePath'
+  | 'lyricsTextDirection'
   | 'lyricsLineSpacingPercent'
   | 'lyricsLineMaxChars'
   | 'lyricsContextOpacityPercent'
@@ -114,6 +116,7 @@ type LyricsDrawerSettings = Pick<
   | 'desktopLyricsFontFamily'
   | 'desktopLyricsFontFilePath'
   | 'desktopLyricsOpacityPercent'
+  | 'desktopLyricsTextDirection'
   | 'desktopLyricsRomanizationEnabled'
   | 'desktopLyricsTranslationEnabled'
 >;
@@ -153,6 +156,7 @@ const fallbackSettings: LyricsDrawerSettings = {
   lyricsSecondaryFontSizePx: 22,
   lyricsFontFamily: 'Microsoft YaHei',
   lyricsFontFilePath: null,
+  lyricsTextDirection: 'horizontal',
   lyricsLineSpacingPercent: 110,
   lyricsLineMaxChars: 0,
   lyricsContextOpacityPercent: 49,
@@ -168,6 +172,7 @@ const fallbackSettings: LyricsDrawerSettings = {
   desktopLyricsFontFamily: 'Microsoft YaHei',
   desktopLyricsFontFilePath: null,
   desktopLyricsOpacityPercent: 96,
+  desktopLyricsTextDirection: 'horizontal',
   desktopLyricsRomanizationEnabled: true,
   desktopLyricsTranslationEnabled: true,
 };
@@ -612,6 +617,7 @@ const selectLyricsSettings = (settings: AppSettings): LyricsDrawerSettings => ({
   lyricsSecondaryFontSizePx: settings.lyricsSecondaryFontSizePx ?? fallbackSettings.lyricsSecondaryFontSizePx,
   lyricsFontFamily: settings.lyricsFontFamily ?? fallbackSettings.lyricsFontFamily,
   lyricsFontFilePath: settings.lyricsFontFilePath ?? fallbackSettings.lyricsFontFilePath,
+  lyricsTextDirection: settings.lyricsTextDirection ?? fallbackSettings.lyricsTextDirection,
   lyricsLineSpacingPercent: settings.lyricsLineSpacingPercent ?? fallbackSettings.lyricsLineSpacingPercent,
   lyricsLineMaxChars: settings.lyricsLineMaxChars ?? fallbackSettings.lyricsLineMaxChars,
   lyricsContextOpacityPercent: settings.lyricsContextOpacityPercent ?? fallbackSettings.lyricsContextOpacityPercent,
@@ -627,6 +633,7 @@ const selectLyricsSettings = (settings: AppSettings): LyricsDrawerSettings => ({
   desktopLyricsFontFamily: settings.desktopLyricsFontFamily ?? fallbackSettings.desktopLyricsFontFamily,
   desktopLyricsFontFilePath: settings.desktopLyricsFontFilePath ?? fallbackSettings.desktopLyricsFontFilePath,
   desktopLyricsOpacityPercent: settings.desktopLyricsOpacityPercent ?? fallbackSettings.desktopLyricsOpacityPercent,
+  desktopLyricsTextDirection: settings.desktopLyricsTextDirection ?? fallbackSettings.desktopLyricsTextDirection,
   desktopLyricsRomanizationEnabled: settings.desktopLyricsRomanizationEnabled ?? fallbackSettings.desktopLyricsRomanizationEnabled,
   desktopLyricsTranslationEnabled: settings.desktopLyricsTranslationEnabled ?? fallbackSettings.desktopLyricsTranslationEnabled,
 });
@@ -696,6 +703,11 @@ export const LyricsSettingsPanel = ({ className, variant = 'drawer' }: LyricsSet
     desktopLyricsState?.settings.desktopLyricsTranslationEnabled ??
     effectiveSettings.desktopLyricsTranslationEnabled ??
     fallbackSettings.desktopLyricsTranslationEnabled;
+  const desktopLyricsTextDirection =
+    desktopLyricsState?.settings.desktopLyricsTextDirection ??
+    effectiveSettings.desktopLyricsTextDirection ??
+    fallbackSettings.desktopLyricsTextDirection ??
+    'horizontal';
   const wordHighlightClarityPercent = effectiveSettings.lyricsWordHighlightClarityPercent ?? fallbackSettings.lyricsWordHighlightClarityPercent ?? 70;
   const wordHighlightClarityLabel =
     wordHighlightClarityPercent === fallbackSettings.lyricsWordHighlightClarityPercent ? t('lyricsSettings.status.normal') : `${wordHighlightClarityPercent}%`;
@@ -1898,6 +1910,26 @@ export const LyricsSettingsPanel = ({ className, variant = 'drawer' }: LyricsSet
                   onChange={(event) => patchDesktopLyricsStyle({ desktopLyricsTranslationEnabled: event.currentTarget.checked })}
                 />
               </label>
+              <div className="lyrics-color-panel__header">
+                <span>
+                  <Rows3 size={15} />
+                  <strong>{t('lyricsSettings.display.desktopTextDirection')}</strong>
+                </span>
+                <em>{t(desktopLyricsTextDirection === 'vertical' ? 'lyricsSettings.direction.vertical' : 'lyricsSettings.direction.horizontal')}</em>
+              </div>
+              <div className="lyrics-background-segmented" aria-label={t('lyricsSettings.display.desktopTextDirection')}>
+                {(['horizontal', 'vertical'] as const).map((direction) => (
+                  <button
+                    type="button"
+                    key={direction}
+                    aria-pressed={desktopLyricsTextDirection === direction}
+                    disabled={isBusy || isDesktopLyricsBusy || !hasDesktopLyricsBridge}
+                    onClick={() => patchDesktopLyricsStyle({ desktopLyricsTextDirection: direction })}
+                  >
+                    {t(direction === 'vertical' ? 'lyricsSettings.direction.vertical' : 'lyricsSettings.direction.horizontal')}
+                  </button>
+                ))}
+              </div>
 
               <label className="mv-threshold-control lyrics-desktop-opacity-control">
                 <span className="mv-threshold-copy">
@@ -2339,6 +2371,28 @@ export const LyricsSettingsPanel = ({ className, variant = 'drawer' }: LyricsSet
 
           {showPersistentControls ? (
             <div className="lyrics-style-range-grid" hidden={!isLyricsStyleControlsOpen}>
+              <div className="lyrics-color-panel lyrics-text-direction-panel">
+                <div className="lyrics-color-panel__header">
+                  <span>
+                    <Rows3 size={15} />
+                    <strong>{t('lyricsSettings.style.textDirection')}</strong>
+                  </span>
+                  <em>{t(effectiveSettings.lyricsTextDirection === 'vertical' ? 'lyricsSettings.direction.vertical' : 'lyricsSettings.direction.horizontal')}</em>
+                </div>
+                <div className="lyrics-background-segmented" aria-label={t('lyricsSettings.style.textDirection')}>
+                  {(['horizontal', 'vertical'] as const).map((direction) => (
+                    <button
+                      type="button"
+                      key={direction}
+                      aria-pressed={(effectiveSettings.lyricsTextDirection ?? 'horizontal') === direction}
+                      disabled={isBusy}
+                      onClick={() => void patchSettings({ lyricsTextDirection: direction })}
+                    >
+                      {t(direction === 'vertical' ? 'lyricsSettings.direction.vertical' : 'lyricsSettings.direction.horizontal')}
+                    </button>
+                  ))}
+                </div>
+              </div>
           {isSecondaryLyricsSizeOpen ? (
             <label className="lyrics-drawer-range lyrics-secondary-size-range">
               <span>

--- a/src/renderer/components/lyrics/LyricsView.tsx
+++ b/src/renderer/components/lyrics/LyricsView.tsx
@@ -8,11 +8,13 @@ import { shouldShowRomanizationForLyrics } from '../../../shared/utils/lyricsLan
 import { translateFallback, useOptionalI18n } from '../../i18n/I18nProvider';
 
 type LyricScrollMode = 'animated' | 'instant' | 'recenter';
+type LyricsTextDirection = 'horizontal' | 'vertical';
 const lyricsLayoutSettingKeys = new Set([
   'lyricsFontSizePx',
   'lyricsSecondaryFontSizePx',
   'lyricsFontFamily',
   'lyricsFontFilePath',
+  'lyricsTextDirection',
   'lyricsLineSpacingPercent',
   'lyricsLineMaxChars',
   'lyricsRomanizationEnabled',
@@ -36,6 +38,7 @@ type LyricsViewProps = {
   showTranslation?: boolean;
   wordHighlightEnabled?: boolean;
   highFrequencyUpdatesEnabled?: boolean;
+  textDirection?: LyricsTextDirection;
 };
 
 const activeIndexSearchCache = new WeakMap<LyricsState['lines'], boolean>();
@@ -232,7 +235,6 @@ const getCurrentWordIndex = (
   }
 
   for (let index = 0; index < words.length; index += 1) {
-    const word = words[index];
     const endMs = getWordEndMs(words, index, fallbackLineEndMs);
     if (adjustedPositionMs < endMs) {
       return index;
@@ -309,6 +311,7 @@ export const LyricsView = ({
   showTranslation = true,
   wordHighlightEnabled = true,
   highFrequencyUpdatesEnabled = true,
+  textDirection = 'horizontal',
 }: LyricsViewProps): JSX.Element | null => {
   const t = useOptionalI18n()?.t ?? translateFallback;
   const scrollRef = useRef<HTMLElement | null>(null);
@@ -761,6 +764,7 @@ export const LyricsView = ({
       className="lyrics-scroll"
       aria-label="Lyrics"
       data-kind={lyrics.kind}
+      data-text-direction={textDirection}
       ref={scrollRef}
       onContextMenu={onContextMenu}
     >
@@ -775,6 +779,7 @@ export const LyricsView = ({
           showRomanization={canShowRomanization}
           preferKanaPronunciation={preferKanaPronunciation}
           showTranslation={showTranslation}
+          textDirection={textDirection}
           wordHighlightEnabled={wordHighlightEnabled && !prefersReducedMotion()}
           onSeek={onSeek}
           seekable={false}

--- a/src/renderer/components/lyrics/VerticalText.tsx
+++ b/src/renderer/components/lyrics/VerticalText.tsx
@@ -1,0 +1,62 @@
+type VerticalTextProps = {
+  className: string;
+  text: string;
+};
+
+export type VerticalTextToken = {
+  key: string;
+  sideways: boolean;
+  text: string;
+};
+
+const verticalSidewaysPattern = /[A-Za-z0-9]+(?:[.'’-][A-Za-z0-9]+)*/uy;
+
+export const tokenizeVerticalText = (text: string): VerticalTextToken[] => {
+  const tokens: VerticalTextToken[] = [];
+  let index = 0;
+
+  while (index < text.length) {
+    verticalSidewaysPattern.lastIndex = index;
+    const sidewaysMatch = verticalSidewaysPattern.exec(text);
+    if (sidewaysMatch?.index === index) {
+      const [token] = sidewaysMatch;
+      tokens.push({
+        key: `${index}-${token}`,
+        sideways: true,
+        text: token,
+      });
+      index += token.length;
+      continue;
+    }
+
+    const [char] = Array.from(text.slice(index));
+    if (/\s/u.test(char)) {
+      index += char.length;
+      continue;
+    }
+
+    tokens.push({
+      key: `${index}-${char}`,
+      sideways: false,
+      text: char,
+    });
+    index += char.length;
+  }
+
+  return tokens;
+};
+
+export const VerticalText = ({ className, text }: VerticalTextProps): JSX.Element => (
+  <>
+    {tokenizeVerticalText(text).map((token) => (
+      <span
+        aria-hidden="true"
+        className={className}
+        data-sideways={token.sideways || undefined}
+        key={token.key}
+      >
+        {token.text}
+      </span>
+    ))}
+  </>
+);

--- a/src/renderer/desktop-lyrics/DesktopLyricsApp.test.tsx
+++ b/src/renderer/desktop-lyrics/DesktopLyricsApp.test.tsx
@@ -1,16 +1,22 @@
 // @vitest-environment jsdom
+import { readFileSync } from 'node:fs';
 import { act, cleanup, fireEvent, render, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { ConnectSessionStatus } from '../../shared/types/connect';
+import type { LibraryTrack } from '../../shared/types/library';
+import type { LyricLine, TrackLyrics } from '../../shared/types/lyrics';
+import type { PlaybackStatus } from '../../shared/types/playback';
 import {
   DesktopLyricsApp,
   getInterpolatedPositionMs,
+  getDesktopLyricsLineProgress,
   getDesktopLyricsTextFitScale,
   hqPlayerConnectStatusToDesktopLyricsClock,
+  selectDesktopLyricsActiveClock,
   shouldShowDesktopLyricsText,
 } from './DesktopLyricsApp';
 
-const makeDesktopLyricsSettings = (locked: boolean) => ({
+const makeDesktopLyricsSettingsBase = (locked: boolean) => ({
   desktopLyricsEnabled: true,
   desktopLyricsLocked: locked,
   desktopLyricsFontSizePx: 34,
@@ -23,14 +29,105 @@ const makeDesktopLyricsSettings = (locked: boolean) => ({
   desktopLyricsOpacityPercent: 96,
   desktopLyricsRomanizationEnabled: true,
   desktopLyricsTranslationEnabled: true,
+  desktopLyricsTextDirection: 'horizontal',
   desktopLyricsBounds: null,
+});
+
+const makeDesktopLyricsSettings = (
+  locked: boolean,
+  overrides: Partial<ReturnType<typeof makeDesktopLyricsSettingsBase>> = {},
+) => ({
+  ...makeDesktopLyricsSettingsBase(locked),
+  ...overrides,
+});
+
+const makeDesktopLyricsTrack = (overrides: Partial<LibraryTrack> = {}): LibraryTrack => ({
+  id: 'track-1',
+  path: 'D:\\Music\\Song.flac',
+  title: 'Song',
+  artist: 'Artist',
+  album: '',
+  albumArtist: '',
+  trackNo: null,
+  discNo: null,
+  year: null,
+  genre: null,
+  duration: 188,
+  codec: null,
+  sampleRate: null,
+  bitDepth: null,
+  bitrate: null,
+  coverId: null,
+  coverThumb: null,
+  fieldSources: {},
+  mediaType: 'local',
+  ...overrides,
+});
+
+const makeDesktopTrackLyrics = (
+  lines: LyricLine[],
+  overrides: Partial<TrackLyrics> = {},
+): TrackLyrics => ({
+  id: 'lyrics-1',
+  trackId: 'track-1',
+  provider: 'lrclib',
+  kind: 'synced',
+  title: 'Song',
+  artist: 'Artist',
+  album: null,
+  durationSeconds: 188,
+  lines,
+  offsetMs: 0,
+  cachedAt: '2026-05-25T00:00:00.000Z',
+  updatedAt: '2026-05-25T00:00:00.000Z',
+  ...overrides,
 });
 
 const renderDesktopLyricsApp = (
   locked: boolean,
-): { container: HTMLElement; setMousePassthrough: ReturnType<typeof vi.fn> } => {
-  const settings = makeDesktopLyricsSettings(locked);
+  options: {
+    playbackStatus?: PlaybackStatus;
+    connectStatus?: ConnectSessionStatus | null;
+    settings?: Partial<ReturnType<typeof makeDesktopLyricsSettingsBase>>;
+    track?: LibraryTrack;
+    lyrics?: TrackLyrics | null;
+  } = {},
+): {
+  container: HTMLElement;
+  connectPause: ReturnType<typeof vi.fn>;
+  connectPlay: ReturnType<typeof vi.fn>;
+  playbackPause: ReturnType<typeof vi.fn>;
+  playbackPlay: ReturnType<typeof vi.fn>;
+  setMousePassthrough: ReturnType<typeof vi.fn>;
+  setStyle: ReturnType<typeof vi.fn>;
+} => {
+  const settings = makeDesktopLyricsSettings(locked, options.settings);
+  const track = options.track ?? null;
+  const lyrics = options.lyrics ?? null;
+  const playbackStatus = options.playbackStatus ?? {
+    currentTrackId: null,
+    filePath: null,
+    state: 'stopped',
+    positionMs: 0,
+    durationMs: 0,
+  };
+  const connectStatus = options.connectStatus ?? null;
+  const connectPlay = vi.fn().mockResolvedValue(connectStatus);
+  const connectPause = vi.fn().mockResolvedValue(connectStatus);
+  const playbackPlay = vi.fn().mockResolvedValue({ ...playbackStatus, state: 'playing' });
+  const playbackPause = vi.fn().mockResolvedValue({ ...playbackStatus, state: 'paused' });
   const setMousePassthrough = vi.fn();
+  const setStyle = vi.fn((patch: Partial<ReturnType<typeof makeDesktopLyricsSettingsBase>>) =>
+    Promise.resolve({
+      visible: true,
+      locked,
+      bounds: null,
+      settings: {
+        ...settings,
+        ...patch,
+      },
+    }),
+  );
 
   window.echo = {
     app: {
@@ -38,8 +135,10 @@ const renderDesktopLyricsApp = (
       loadFontFile: vi.fn(),
     },
     connect: {
-      getStatus: vi.fn().mockResolvedValue(null),
+      getStatus: vi.fn().mockResolvedValue(connectStatus),
       onStatus: vi.fn(() => () => undefined),
+      pause: connectPause,
+      play: connectPlay,
     },
     desktopLyrics: {
       getLastAudioStatus: vi.fn().mockResolvedValue(null),
@@ -52,21 +151,28 @@ const renderDesktopLyricsApp = (
       onAudioStatus: vi.fn(() => () => undefined),
       onStateChanged: vi.fn(() => () => undefined),
       setMousePassthrough,
+      setStyle,
     },
     playback: {
-      getStatus: vi.fn().mockResolvedValue({
-        currentTrackId: null,
-        filePath: null,
-        state: 'stopped',
-        positionMs: 0,
-        durationMs: 0,
-      }),
+      getStatus: vi.fn().mockResolvedValue(playbackStatus),
+      pause: playbackPause,
+      play: playbackPlay,
     },
   } as unknown as typeof window.echo;
+  if (track) {
+    window.echo.library = {
+      getTrack: vi.fn().mockResolvedValue(track),
+    } as unknown as typeof window.echo.library;
+  }
+  if (lyrics) {
+    window.echo.lyrics = {
+      getForTrack: vi.fn().mockResolvedValue(lyrics),
+    } as unknown as typeof window.echo.lyrics;
+  }
 
   const { container } = render(<DesktopLyricsApp />);
 
-  return { container, setMousePassthrough };
+  return { container, connectPause, connectPlay, playbackPause, playbackPlay, setMousePassthrough, setStyle };
 };
 
 afterEach(() => {
@@ -77,6 +183,13 @@ afterEach(() => {
 });
 
 describe('desktop lyrics text fitting', () => {
+  it('keeps vertical desktop lyric columns close together', () => {
+    const css = readFileSync('src/renderer/styles/desktop-lyrics.css', 'utf8');
+
+    expect(css).toMatch(/\.desktop-lyrics-app\[data-text-direction="vertical"\] \.desktop-lyrics-line-text \{[\s\S]*?gap: clamp\(6px, 1\.4vw, 18px\);/);
+    expect(css).toMatch(/\.desktop-lyrics-upright-character\[data-sideways="true"\] \+ \.desktop-lyrics-upright-character\[data-sideways="true"\][\s\S]*?margin-top: 0\.28em;/);
+  });
+
   it('hides text that would overflow the desktop lyrics window', () => {
     expect(shouldShowDesktopLyricsText({
       text: '短歌词',
@@ -117,6 +230,97 @@ describe('desktop lyrics text fitting', () => {
     });
 
     expect(fitScale).toBeGreaterThanOrEqual(0.62);
+    expect(fitScale).toBeLessThan(1);
+  });
+
+  it('fits vertical desktop lyrics against the available height', () => {
+    expect(shouldShowDesktopLyricsText({
+      text: '短歌词',
+      availableWidthPx: 32,
+      availableHeightPx: 320,
+      fontSizePx: 34,
+      fontFamily: '"Microsoft YaHei", sans-serif',
+      fontWeight: 700,
+      scalePercent: 100,
+      textDirection: 'vertical',
+    })).toBe(true);
+
+    const fitScale = getDesktopLyricsTextFitScale({
+      text: 'Wonderland '.repeat(10),
+      availableWidthPx: 1200,
+      availableHeightPx: 180,
+      fontSizePx: 34,
+      fontFamily: '"Microsoft YaHei", sans-serif',
+      fontWeight: 700,
+      scalePercent: 100,
+      textDirection: 'vertical',
+    });
+
+    expect(fitScale).toBe(1);
+  });
+
+  it('fits sideways latin runs in vertical desktop lyrics without per-letter height', () => {
+    expect(shouldShowDesktopLyricsText({
+      text: 'The tenacity',
+      availableWidthPx: 32,
+      availableHeightPx: 240,
+      fontSizePx: 34,
+      fontFamily: '"Microsoft YaHei", sans-serif',
+      fontWeight: 700,
+      scalePercent: 100,
+      textDirection: 'vertical',
+    })).toBe(true);
+  });
+
+  it('keeps horizontal desktop lyrics on the existing minimum fit scale', () => {
+    const fitScale = getDesktopLyricsTextFitScale({
+      text: 'Wonderland '.repeat(20),
+      availableWidthPx: 120,
+      fontSizePx: 34,
+      fontFamily: '"Microsoft YaHei", sans-serif',
+      fontWeight: 700,
+      scalePercent: 100,
+    });
+
+    expect(fitScale).toBe(0.62);
+  });
+
+  it('computes vertical scroll progress from the active lyric timing', () => {
+    const performanceNow = vi.spyOn(performance, 'now').mockReturnValue(1_000);
+    const progress = getDesktopLyricsLineProgress(
+      [
+        { timeMs: 10_000, text: 'first line' },
+        { timeMs: 14_000, text: 'second line' },
+      ],
+      0,
+      {
+        source: 'playback',
+        currentTrackId: 'track-1',
+        filePath: 'D:\\Music\\Song.flac',
+        state: 'playing',
+        positionMs: 11_000,
+        durationMs: 180_000,
+        playbackRate: 1,
+        updatedAtMs: 0,
+      },
+      0,
+    );
+
+    expect(progress).toBe(0.5);
+    performanceNow.mockRestore();
+  });
+
+  it('uses the horizontal width when fitting horizontal desktop lyrics', () => {
+    const fitScale = getDesktopLyricsTextFitScale({
+      text: 'Wonderland '.repeat(10),
+      availableWidthPx: 320,
+      availableHeightPx: 1800,
+      fontSizePx: 34,
+      fontFamily: '"Microsoft YaHei", sans-serif',
+      fontWeight: 700,
+      scalePercent: 100,
+    });
+
     expect(fitScale).toBeLessThan(1);
   });
 
@@ -246,6 +450,422 @@ describe('desktop lyrics text fitting', () => {
     await waitFor(() => expect(app?.getAttribute('data-menu-visible')).toBe('false'));
   });
 
+  it('toggles the desktop lyrics text direction from the floating menu', async () => {
+    const { container, setStyle } = renderDesktopLyricsApp(false);
+    const app = container.querySelector<HTMLElement>('.desktop-lyrics-app');
+
+    await waitFor(() => expect(app?.getAttribute('data-text-direction')).toBe('horizontal'));
+    fireEvent.click(await waitFor(() => {
+      const button = container.querySelector<HTMLButtonElement>('button[aria-label="切换横排 / 竖排"]');
+      expect(button).toBeTruthy();
+      return button!;
+    }));
+
+    await waitFor(() => expect(setStyle).toHaveBeenCalledWith({ desktopLyricsTextDirection: 'vertical' }));
+    expect(app?.getAttribute('data-text-direction')).toBe('vertical');
+  });
+
+  it('keeps romanization and translation grouped with vertical desktop lyrics', async () => {
+    const { container } = renderDesktopLyricsApp(false, {
+      settings: { desktopLyricsTextDirection: 'vertical' },
+      track: makeDesktopLyricsTrack(),
+      lyrics: makeDesktopTrackLyrics([{
+        timeMs: 0,
+        text: 'らくになる日はまず来ない',
+        romanization: 'ra ku ni na ru hi wa ma zu ko na i',
+        translation: '轻松的生活不会到来',
+      }]),
+      playbackStatus: {
+        currentTrackId: 'track-1',
+        filePath: 'D:\\Music\\Song.flac',
+        state: 'playing',
+        positionMs: 0,
+        durationMs: 188_000,
+      },
+    });
+
+    await waitFor(() => expect(container.querySelector('.desktop-lyrics-app')?.getAttribute('data-text-direction')).toBe('vertical'));
+    await waitFor(() => expect(container.querySelector('.desktop-lyrics-line-text strong')?.textContent).toBe('らくになる日はまず来ない'));
+    const lineText = container.querySelector('.desktop-lyrics-line-text');
+    const secondaryTextElements = Array.from(lineText?.children ?? []).filter((element) => element.tagName === 'SPAN');
+    expect(lineText?.querySelector('strong')?.textContent).toBe('らくになる日はまず来ない');
+    expect(secondaryTextElements[0]?.textContent).toBe('rakuninaruhiwamazukonai');
+    expect(secondaryTextElements[1]?.textContent).toBe('轻松的生活不会到来');
+    expect(secondaryTextElements[0]?.getAttribute('data-secondary-kind')).toBe('romanization');
+    expect(secondaryTextElements[1]?.getAttribute('data-secondary-kind')).toBe('translation');
+    expect(lineText?.querySelectorAll('strong .desktop-lyrics-upright-character').length).toBe(
+      Array.from('らくになる日はまず来ない').length,
+    );
+    const romanizationTokens = Array.from(
+      lineText?.querySelectorAll<HTMLElement>('[data-secondary-kind="romanization"] .desktop-lyrics-romanization-token') ?? [],
+    );
+    expect(romanizationTokens.map((token) => token.textContent)).toEqual([
+      'ra',
+      'ku',
+      'ni',
+      'na',
+      'ru',
+      'hi',
+      'wa',
+      'ma',
+      'zu',
+      'ko',
+      'na',
+      'i',
+    ]);
+    expect(lineText?.querySelectorAll('[data-secondary-kind="romanization"] .desktop-lyrics-romanization-character[data-sideways="true"]').length).toBeGreaterThan(0);
+    expect(lineText?.querySelectorAll('[data-secondary-kind="translation"] .desktop-lyrics-upright-character').length).toBe(
+      Array.from('轻松的生活不会到来').length,
+    );
+  });
+
+  it('renders latin text sideways in vertical desktop lyrics', async () => {
+    const { container } = renderDesktopLyricsApp(false, {
+      settings: { desktopLyricsTextDirection: 'vertical' },
+      track: makeDesktopLyricsTrack(),
+      lyrics: makeDesktopTrackLyrics([
+        { timeMs: 0, text: 'The tenacity', translation: '坚如磐石' },
+      ]),
+      playbackStatus: {
+        currentTrackId: 'track-1',
+        filePath: 'D:\\Music\\Song.flac',
+        state: 'playing',
+        positionMs: 0,
+        durationMs: 188_000,
+      },
+    });
+
+    const sidewaysTokens = await waitFor(() => {
+      const tokens = Array.from(container.querySelectorAll<HTMLElement>('strong .desktop-lyrics-upright-character[data-sideways="true"]'));
+      expect(tokens.map((token) => token.textContent)).toEqual(['The', 'tenacity']);
+      return tokens;
+    });
+
+    expect(sidewaysTokens).toHaveLength(2);
+    expect(container.querySelectorAll('strong .desktop-lyrics-upright-character')).toHaveLength(2);
+  });
+
+  it('keeps vertical desktop lyrics at the configured size when romanization is long', async () => {
+    const { container } = renderDesktopLyricsApp(false, {
+      settings: { desktopLyricsTextDirection: 'vertical' },
+      track: makeDesktopLyricsTrack(),
+      lyrics: makeDesktopTrackLyrics([{
+        timeMs: 0,
+        text: '短い歌詞',
+        romanization: 'ra ku ni na ru hi wa ma zu ko na i '.repeat(4).trim(),
+        translation: '很长的翻译文本'.repeat(8),
+      }]),
+      playbackStatus: {
+        currentTrackId: 'track-1',
+        filePath: 'D:\\Music\\Song.flac',
+        state: 'playing',
+        positionMs: 0,
+        durationMs: 188_000,
+      },
+    });
+
+    await waitFor(() => expect(container.querySelector('.desktop-lyrics-app')?.getAttribute('data-text-direction')).toBe('vertical'));
+    const lineText = container.querySelector<HTMLElement>('.desktop-lyrics-line-text');
+    expect(lineText?.style.getPropertyValue('--desktop-lyrics-text-fit-scale')).toBe('1.000');
+    expect(Number(lineText?.style.getPropertyValue('--desktop-lyrics-line-progress'))).toBeGreaterThanOrEqual(0);
+    expect(Number(lineText?.style.getPropertyValue('--desktop-lyrics-line-progress'))).toBeLessThan(0.01);
+    expect(lineText?.style.getPropertyValue('--desktop-lyrics-secondary-text-fit-scale')).toBe('');
+    expect(lineText?.querySelectorAll('.desktop-lyrics-scroll-track').length).toBe(lineText?.children.length);
+    expect(container.querySelector('.desktop-lyrics-lines strong')?.textContent).toBe('短い歌詞');
+  });
+
+  it('centers fitting vertical desktop columns and scrolls overflowing columns by lyric progress', async () => {
+    const resizeObserverDescriptor = Object.getOwnPropertyDescriptor(window, 'ResizeObserver');
+    const innerHeightDescriptor = Object.getOwnPropertyDescriptor(window, 'innerHeight');
+    vi.spyOn(performance, 'now').mockReturnValue(1_000);
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation((callback) => {
+      callback(1_000);
+      return 1;
+    });
+    vi.spyOn(window, 'cancelAnimationFrame').mockImplementation(() => undefined);
+    Object.defineProperty(window, 'ResizeObserver', {
+      configurable: true,
+      value: undefined,
+    });
+    Object.defineProperty(window, 'innerHeight', {
+      configurable: true,
+      value: 220,
+    });
+
+    const options = {
+      settings: { desktopLyricsTextDirection: 'vertical' as const },
+      track: makeDesktopLyricsTrack(),
+      lyrics: makeDesktopTrackLyrics([
+        {
+          timeMs: 0,
+          text: '短い歌詞',
+          romanization: 'ra ku ni na ru hi wa ma zu ko na i '.repeat(4).trim(),
+          translation: '居中翻译',
+        },
+        { timeMs: 4_000, text: 'next line' },
+      ]),
+      playbackStatus: {
+        currentTrackId: 'track-1',
+        filePath: 'D:\\Music\\Song.flac',
+        state: 'paused' as const,
+        positionMs: 2_000,
+        durationMs: 188_000,
+      },
+    };
+
+    try {
+      const { container } = renderDesktopLyricsApp(false, options);
+
+      await waitFor(() => {
+        const lineTextElement = container.querySelector('.desktop-lyrics-line-text');
+        expect(lineTextElement).toBeTruthy();
+        expect(lineTextElement?.textContent).toContain('居中翻译');
+      });
+      const lineText = container.querySelector<HTMLElement>('.desktop-lyrics-line-text');
+      const clips = Array.from(lineText?.querySelectorAll<HTMLElement>('.desktop-lyrics-scroll-clip') ?? []);
+      const tracks = Array.from(lineText?.querySelectorAll<HTMLElement>('.desktop-lyrics-scroll-track') ?? []);
+      expect(clips.length).toBe(2);
+
+      Object.defineProperty(clips[0], 'clientHeight', { configurable: true, value: 200 });
+      Object.defineProperty(tracks[0], 'scrollHeight', { configurable: true, value: 120 });
+      Object.defineProperty(clips[1], 'clientHeight', { configurable: true, value: 200 });
+      Object.defineProperty(tracks[1], 'scrollHeight', { configurable: true, value: 520 });
+
+      window.dispatchEvent(new Event('resize'));
+
+      await waitFor(() => expect(clips[1].dataset.overflow).toBe('true'));
+      expect(clips[0].dataset.overflow).toBe('false');
+      expect(tracks[1].style.getPropertyValue('--desktop-lyrics-scroll-offset')).toBe('-160.00px');
+      expect(tracks[0].style.getPropertyValue('--desktop-lyrics-scroll-offset')).toBe('0.00px');
+    } finally {
+      if (resizeObserverDescriptor) {
+        Object.defineProperty(window, 'ResizeObserver', resizeObserverDescriptor);
+      } else {
+        Reflect.deleteProperty(window, 'ResizeObserver');
+      }
+      if (innerHeightDescriptor) {
+        Object.defineProperty(window, 'innerHeight', innerHeightDescriptor);
+      }
+    }
+  });
+
+  it('pauses native playback from the floating menu while playing', async () => {
+    const { container, playbackPause, playbackPlay, connectPause } = renderDesktopLyricsApp(false, {
+      playbackStatus: {
+        currentTrackId: 'track-1',
+        filePath: 'D:\\Music\\Song.flac',
+        state: 'playing',
+        positionMs: 12_000,
+        durationMs: 180_000,
+      },
+    });
+
+    fireEvent.click(await waitFor(() => {
+      const button = container.querySelector<HTMLButtonElement>('button[aria-label="暂停"]');
+      expect(button).toBeTruthy();
+      return button!;
+    }));
+
+    await waitFor(() => expect(playbackPause).toHaveBeenCalledTimes(1));
+    expect(playbackPause).toHaveBeenCalledWith();
+    expect(playbackPlay).not.toHaveBeenCalled();
+    expect(connectPause).not.toHaveBeenCalled();
+  });
+
+  it('resumes native playback from the floating menu while paused', async () => {
+    const { container, playbackPause, playbackPlay } = renderDesktopLyricsApp(false, {
+      playbackStatus: {
+        currentTrackId: 'track-1',
+        filePath: 'D:\\Music\\Song.flac',
+        state: 'paused',
+        positionMs: 12_000,
+        durationMs: 180_000,
+      },
+    });
+
+    fireEvent.click(await waitFor(() => {
+      const button = container.querySelector<HTMLButtonElement>('button[aria-label="播放"]');
+      expect(button).toBeTruthy();
+      return button!;
+    }));
+
+    await waitFor(() => expect(playbackPlay).toHaveBeenCalledTimes(1));
+    expect(playbackPlay).toHaveBeenCalledWith();
+    expect(playbackPause).not.toHaveBeenCalled();
+  });
+
+  it('keeps the desktop lyric clock moving from the resume click while native playback is pending', async () => {
+    let frameId = 0;
+    const frames = new Map<number, FrameRequestCallback>();
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation((callback) => {
+      frameId += 1;
+      frames.set(frameId, callback);
+      return frameId;
+    });
+    vi.spyOn(window, 'cancelAnimationFrame').mockImplementation((id) => {
+      frames.delete(id);
+    });
+    const performanceNow = vi.spyOn(performance, 'now').mockReturnValue(0);
+    const settings = makeDesktopLyricsSettings(false);
+    const pausedStatus: PlaybackStatus = {
+      currentTrackId: 'track-1',
+      filePath: 'D:\\Music\\Song.flac',
+      state: 'paused',
+      positionMs: 12_000,
+      durationMs: 180_000,
+    };
+    let resolvePlay: ((status: PlaybackStatus) => void) | null = null;
+    const playbackPlay = vi.fn(() => new Promise<PlaybackStatus>((resolve) => {
+      resolvePlay = resolve;
+    }));
+
+    window.echo = {
+      app: {
+        getSettings: vi.fn().mockResolvedValue(settings),
+        loadFontFile: vi.fn(),
+      },
+      connect: {
+        getStatus: vi.fn().mockResolvedValue(null),
+        onStatus: vi.fn(() => () => undefined),
+      },
+      desktopLyrics: {
+        getLastAudioStatus: vi.fn().mockResolvedValue(null),
+        getState: vi.fn().mockResolvedValue({
+          visible: true,
+          locked: false,
+          bounds: null,
+          settings,
+        }),
+        onAudioStatus: vi.fn(() => () => undefined),
+        onStateChanged: vi.fn(() => () => undefined),
+        setMousePassthrough: vi.fn(),
+        setStyle: vi.fn(),
+      },
+      library: {
+        getTrack: vi.fn().mockResolvedValue({
+          id: 'track-1',
+          path: 'D:\\Music\\Song.flac',
+          title: 'Song',
+          artist: 'Artist',
+          album: null,
+          albumArtist: null,
+          duration: 180,
+          mediaType: 'local',
+        }),
+      },
+      lyrics: {
+        getForTrack: vi.fn().mockResolvedValue({
+          kind: 'synced',
+          provider: 'lrclib',
+          lines: [
+            { timeMs: 12_000, text: 'resume line' },
+            { timeMs: 12_600, text: 'on beat line' },
+          ],
+          offsetMs: 0,
+        }),
+      },
+      playback: {
+        getStatus: vi.fn().mockResolvedValue(pausedStatus),
+        pause: vi.fn(),
+        play: playbackPlay,
+      },
+    } as unknown as typeof window.echo;
+
+    const { container } = render(<DesktopLyricsApp />);
+
+    await waitFor(() => expect(container.querySelector('.desktop-lyrics-lines strong')?.textContent).toBe('resume line'));
+
+    fireEvent.click(await waitFor(() => {
+      const button = container.querySelector<HTMLButtonElement>('button[aria-label="播放"]');
+      expect(button).toBeTruthy();
+      return button!;
+    }));
+    await waitFor(() => expect(playbackPlay).toHaveBeenCalledTimes(1));
+    expect(playbackPlay).toHaveBeenCalledWith();
+
+    performanceNow.mockReturnValue(700);
+    act(() => {
+      for (const [id, callback] of Array.from(frames.entries())) {
+        frames.delete(id);
+        callback(700);
+      }
+    });
+
+    await waitFor(() => expect(container.querySelector('.desktop-lyrics-lines strong')?.textContent).toBe('on beat line'));
+
+    await act(async () => {
+      resolvePlay?.({ ...pausedStatus, state: 'playing' });
+    });
+    performanceNow.mockReturnValue(800);
+    act(() => {
+      for (const [id, callback] of Array.from(frames.entries())) {
+        frames.delete(id);
+        callback(800);
+      }
+    });
+
+    expect(container.querySelector('.desktop-lyrics-lines strong')?.textContent).toBe('on beat line');
+  });
+
+  it('prefers Connect playback controls when the active desktop clock is from Connect', async () => {
+    const connectStatus: ConnectSessionStatus = {
+      deviceId: 'hqplayer:local-desktop',
+      protocol: 'hqplayer',
+      state: 'playing',
+      currentTrackId: 'connect-track',
+      metadata: {
+        title: 'Connect Track',
+        artist: 'Artist',
+        album: null,
+        albumArtist: null,
+        durationSeconds: 180,
+        coverHttpUrl: '',
+      },
+      positionSeconds: 12,
+      durationSeconds: 180,
+      latencyMs: null,
+      error: null,
+      updatedAt: '2026-05-25T00:00:00.000Z',
+    };
+    const { container, connectPause, playbackPause } = renderDesktopLyricsApp(false, { connectStatus });
+
+    fireEvent.click(await waitFor(() => {
+      const button = container.querySelector<HTMLButtonElement>('button[aria-label="暂停"]');
+      expect(button).toBeTruthy();
+      return button!;
+    }));
+
+    await waitFor(() => expect(connectPause).toHaveBeenCalledTimes(1));
+    expect(playbackPause).not.toHaveBeenCalled();
+  });
+
+  it('keeps a local playback command clock ahead of older forwarded desktop lyrics status', () => {
+    const playbackClock = {
+      source: 'playback' as const,
+      currentTrackId: 'track-1',
+      filePath: 'D:\\Music\\Song.flac',
+      state: 'playing',
+      positionMs: 12_700,
+      durationMs: 180_000,
+      playbackRate: 1,
+      updatedAtMs: 700,
+    };
+    const forwardedClock = {
+      ...playbackClock,
+      source: 'forwarded' as const,
+      positionMs: 12_000,
+      updatedAtMs: 100,
+    };
+
+    expect(selectDesktopLyricsActiveClock({
+      forwardedClock,
+      forwardedUpdatedAtMs: 100,
+      nowMs: 800,
+      playbackClock,
+      playbackClockPriorityUntilMs: 2_000,
+    })).toBe(playbackClock);
+  });
+
   it('does not reveal the desktop lyrics menu over transparent window space', async () => {
     const { container, setMousePassthrough } = renderDesktopLyricsApp(false);
     const app = container.querySelector<HTMLElement>('.desktop-lyrics-app');
@@ -286,7 +906,7 @@ describe('desktop lyrics text fitting', () => {
     expect(setMousePassthrough).toHaveBeenCalledWith(false);
   });
 
-  it('does not reveal the desktop lyrics menu over lyrics container empty space', async () => {
+  it('reveals the desktop lyrics menu over the whole unlocked lyrics container', async () => {
     const { container, setMousePassthrough } = renderDesktopLyricsApp(false);
     const app = container.querySelector<HTMLElement>('.desktop-lyrics-app');
     const lines = container.querySelector<HTMLElement>('.desktop-lyrics-lines');
@@ -302,7 +922,43 @@ describe('desktop lyrics text fitting', () => {
     });
     window.dispatchEvent(new MouseEvent('mousemove', { clientX: 120, clientY: 40 }));
 
-    expect(app?.getAttribute('data-menu-visible')).toBe('false');
+    await waitFor(() => expect(app?.getAttribute('data-menu-visible')).toBe('true'));
+    expect(setMousePassthrough).toHaveBeenCalledWith(false);
+  });
+
+  it('reveals the desktop lyrics menu from the vertical lyrics hit rectangle', async () => {
+    const { container, setMousePassthrough } = renderDesktopLyricsApp(false, {
+      settings: { desktopLyricsTextDirection: 'vertical' },
+    });
+    const app = container.querySelector<HTMLElement>('.desktop-lyrics-app');
+    const lines = container.querySelector<HTMLElement>('.desktop-lyrics-lines');
+
+    expect(app).toBeTruthy();
+    expect(lines).toBeTruthy();
+    await waitFor(() => expect(setMousePassthrough).toHaveBeenCalledWith(true));
+    setMousePassthrough.mockClear();
+
+    Object.defineProperty(lines, 'getBoundingClientRect', {
+      configurable: true,
+      value: vi.fn(() => ({
+        bottom: 580,
+        height: 520,
+        left: 180,
+        right: 320,
+        top: 60,
+        width: 140,
+        x: 180,
+        y: 60,
+        toJSON: () => ({}),
+      })),
+    });
+    Object.defineProperty(document, 'elementFromPoint', {
+      configurable: true,
+      value: vi.fn(() => app),
+    });
+    window.dispatchEvent(new MouseEvent('mousemove', { clientX: 250, clientY: 320 }));
+
+    await waitFor(() => expect(app?.getAttribute('data-menu-visible')).toBe('true'));
     expect(setMousePassthrough).toHaveBeenCalledWith(false);
   });
 

--- a/src/renderer/desktop-lyrics/DesktopLyricsApp.tsx
+++ b/src/renderer/desktop-lyrics/DesktopLyricsApp.tsx
@@ -1,6 +1,6 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import type { CSSProperties, FocusEvent as ReactFocusEvent, MouseEvent as ReactMouseEvent } from 'react';
-import { Languages, Lock, Minus, Palette, Plus, RotateCcw, X } from 'lucide-react';
+import { Languages, Lock, Minus, Palette, Pause, Play, Plus, RotateCcw, Rows3, X } from 'lucide-react';
 import type { AudioStatus } from '../../shared/types/audio';
 import type { AppSettings } from '../../shared/types/appSettings';
 import type { ConnectSessionStatus } from '../../shared/types/connect';
@@ -12,6 +12,7 @@ import type { StreamingLyricsResult, StreamingProviderName } from '../../shared/
 import { streamingProviderNames } from '../../shared/types/streaming';
 import { shouldShowRomanizationForLyrics } from '../../shared/utils/lyricsLanguage';
 import { getActiveLyricIndex } from '../components/lyrics/LyricsView';
+import { VerticalText, tokenizeVerticalText } from '../components/lyrics/VerticalText';
 import { titleFromPath } from '../components/player/playerFormat';
 import { logLyricsConsole } from '../diagnostics/lyricsConsole';
 import { translateFallback, useOptionalI18n } from '../i18n/I18nProvider';
@@ -29,6 +30,7 @@ type DesktopLyricsSettings = Required<Pick<
   | 'desktopLyricsColor'
   | 'desktopLyricsStrokeColor'
   | 'desktopLyricsOpacityPercent'
+  | 'desktopLyricsTextDirection'
   | 'desktopLyricsRomanizationEnabled'
   | 'desktopLyricsTranslationEnabled'
 >> & Pick<AppSettings, 'desktopLyricsBounds'>;
@@ -74,6 +76,7 @@ const fallbackSettings: DesktopLyricsSettings = {
   desktopLyricsColor: '#FFFFFF',
   desktopLyricsStrokeColor: '#111827',
   desktopLyricsOpacityPercent: 96,
+  desktopLyricsTextDirection: 'horizontal',
   desktopLyricsRomanizationEnabled: true,
   desktopLyricsTranslationEnabled: true,
   desktopLyricsBounds: null,
@@ -88,20 +91,37 @@ const desktopLyricsClockStaleTelemetryThresholdMs = 750;
 const desktopLyricsClockUnderrunBufferThresholdMs = 40;
 const desktopLyricsStageHorizontalPaddingPx = 36;
 const desktopLyricsOverflowTolerancePx = 4;
-const desktopLyricsMenuRevealSelector = '.desktop-lyrics-lines strong, .desktop-lyrics-lines span, .desktop-lyrics-menu';
+const desktopLyricsHorizontalMinFitScale = 0.62;
+const desktopLyricsPlaybackCommandPriorityMs = 1400;
+const desktopLyricsMenuRevealSelector = '.desktop-lyrics-lines, .desktop-lyrics-menu';
 const desktopLyricsMouseInteractiveSelector = '.desktop-lyrics-lines, .desktop-lyrics-menu';
 const desktopLyricsMenuHideDelayMs = 420;
+const desktopLyricsPointerHitPaddingPx = 12;
 
 const readEnhancedLowLoadPlaybackActive = (settings: Partial<AppSettings> | null | undefined): boolean =>
   settings?.lowLoadPlaybackModeEnabled === true && settings.lowLoadPlaybackEnhancementsEnabled === true;
 
+const isPointInsideRect = (x: number, y: number, rect: DOMRect, padding = 0): boolean =>
+  x >= rect.left - padding &&
+  x <= rect.right + padding &&
+  y >= rect.top - padding &&
+  y <= rect.bottom + padding;
+
+const isPointInsideAnyElementRect = (x: number, y: number, selector: string, padding = 0): boolean =>
+  Array.from(document.querySelectorAll<HTMLElement>(selector)).some((element) => {
+    const rect = element.getBoundingClientRect();
+    return rect.width > 0 && rect.height > 0 && isPointInsideRect(x, y, rect, padding);
+  });
+
 type DesktopLyricsTextFitOptions = {
   text: string;
   availableWidthPx: number;
+  availableHeightPx?: number;
   fontSizePx: number;
   fontFamily: string;
   fontWeight: number;
   scalePercent: number;
+  textDirection?: AppSettings['desktopLyricsTextDirection'];
 };
 
 let desktopLyricsMeasureCanvas: HTMLCanvasElement | null = null;
@@ -111,11 +131,24 @@ const estimateDesktopLyricsTextWidth = (text: string, fontSizePx: number): numbe
     if (/\s/u.test(char)) {
       return width + fontSizePx * 0.35;
     }
-    if (/[\u0000-\u007f]/u.test(char)) {
+    if (char.charCodeAt(0) <= 0x7f) {
       return width + fontSizePx * 0.58;
     }
     return width + fontSizePx;
   }, 0);
+
+const estimateDesktopLyricsVerticalTextHeight = (text: string, fontSizePx: number): number => {
+  const tokens = tokenizeVerticalText(text);
+  return tokens.reduce((height, token, index) => {
+    const tokenHeight = token.sideways
+      ? estimateDesktopLyricsTextWidth(token.text, fontSizePx)
+      : fontSizePx;
+    const wordGapHeight = index > 0 && token.sideways && tokens[index - 1]?.sideways
+      ? fontSizePx * 0.28
+      : 0;
+    return height + wordGapHeight + tokenHeight;
+  }, 0);
+};
 
 const measureDesktopLyricsTextWidth = (
   text: string,
@@ -144,12 +177,14 @@ const measureDesktopLyricsTextWidth = (
 };
 
 export const shouldShowDesktopLyricsText = ({
+  availableHeightPx,
   text,
   availableWidthPx,
   fontSizePx,
   fontFamily,
   fontWeight,
   scalePercent,
+  textDirection = 'horizontal',
 }: DesktopLyricsTextFitOptions): boolean => {
   const normalizedText = text.trim();
   if (!normalizedText) {
@@ -157,8 +192,14 @@ export const shouldShowDesktopLyricsText = ({
   }
 
   const scaledTextWidth =
-    measureDesktopLyricsTextWidth(normalizedText, fontSizePx, fontFamily, fontWeight) * (scalePercent / 100);
-  return scaledTextWidth <= Math.max(0, availableWidthPx) + desktopLyricsOverflowTolerancePx;
+    (textDirection === 'vertical'
+      ? estimateDesktopLyricsVerticalTextHeight(normalizedText, fontSizePx)
+      : measureDesktopLyricsTextWidth(normalizedText, fontSizePx, fontFamily, fontWeight)) * (scalePercent / 100);
+  const availableSizePx =
+    textDirection === 'vertical'
+      ? Math.max(0, availableHeightPx ?? availableWidthPx)
+      : Math.max(0, availableWidthPx);
+  return scaledTextWidth <= availableSizePx + desktopLyricsOverflowTolerancePx;
 };
 
 export const getDesktopLyricsTextFitScale = ({
@@ -168,20 +209,25 @@ export const getDesktopLyricsTextFitScale = ({
   fontFamily,
   fontWeight,
   scalePercent,
+  textDirection = 'horizontal',
 }: DesktopLyricsTextFitOptions): number => {
   const normalizedText = text.trim();
   if (!normalizedText) {
     return 1;
   }
 
-  const scaledTextWidth =
-    measureDesktopLyricsTextWidth(normalizedText, fontSizePx, fontFamily, fontWeight) * (scalePercent / 100);
-  const availableWidth = Math.max(0, availableWidthPx) + desktopLyricsOverflowTolerancePx;
-  if (scaledTextWidth <= availableWidth || availableWidth <= 0) {
+  if (textDirection === 'vertical') {
     return 1;
   }
 
-  return Math.max(0.62, Math.min(1, availableWidth / scaledTextWidth));
+  const scaledTextWidth =
+    measureDesktopLyricsTextWidth(normalizedText, fontSizePx, fontFamily, fontWeight) * (scalePercent / 100);
+  const availableSize = Math.max(0, availableWidthPx) + desktopLyricsOverflowTolerancePx;
+  if (scaledTextWidth <= availableSize || availableSize <= 0) {
+    return 1;
+  }
+
+  return Math.max(desktopLyricsHorizontalMinFitScale, Math.min(1, availableSize / scaledTextWidth));
 };
 
 const emptyLyrics = (offsetMs = 0): DesktopLyricsStateSnapshot => ({
@@ -239,6 +285,7 @@ const pickDesktopLyricsSettings = (settings: Partial<AppSettings> | null | undef
   desktopLyricsColor: settings?.desktopLyricsColor ?? fallbackSettings.desktopLyricsColor,
   desktopLyricsStrokeColor: settings?.desktopLyricsStrokeColor ?? fallbackSettings.desktopLyricsStrokeColor,
   desktopLyricsOpacityPercent: settings?.desktopLyricsOpacityPercent ?? fallbackSettings.desktopLyricsOpacityPercent,
+  desktopLyricsTextDirection: settings?.desktopLyricsTextDirection ?? fallbackSettings.desktopLyricsTextDirection,
   desktopLyricsRomanizationEnabled: settings?.desktopLyricsRomanizationEnabled ?? fallbackSettings.desktopLyricsRomanizationEnabled,
   desktopLyricsTranslationEnabled: settings?.desktopLyricsTranslationEnabled ?? fallbackSettings.desktopLyricsTranslationEnabled,
   desktopLyricsBounds: settings?.desktopLyricsBounds ?? null,
@@ -432,6 +479,51 @@ const clocksHaveSameIdentity = (left: PlaybackClock | null, right: PlaybackClock
 const isActiveClock = (clock: PlaybackClock | null): boolean =>
   Boolean(clock && clockHasIdentity(clock) && ['loading', 'playing', 'paused'].includes(clock.state));
 
+export const selectDesktopLyricsActiveClock = ({
+  forwardedClock,
+  forwardedUpdatedAtMs,
+  nowMs,
+  playbackClock,
+  playbackClockPriorityUntilMs = 0,
+}: {
+  forwardedClock: PlaybackClock | null;
+  forwardedUpdatedAtMs: number;
+  nowMs: number;
+  playbackClock: PlaybackClock | null;
+  playbackClockPriorityUntilMs?: number;
+}): PlaybackClock | null => {
+  const freshForwardedClock =
+    forwardedClock &&
+    clockHasIdentity(forwardedClock) &&
+    nowMs - forwardedUpdatedAtMs <= forwardedStatusMaxAgeMs
+      ? forwardedClock
+      : null;
+
+  if (isActiveClock(playbackClock) && playbackClock?.source === 'connect') {
+    return playbackClock;
+  }
+
+  if (isActiveClock(playbackClock) && nowMs < playbackClockPriorityUntilMs) {
+    return playbackClock;
+  }
+
+  if (!freshForwardedClock) {
+    return playbackClock;
+  }
+
+  const activePlaybackClock = isActiveClock(playbackClock) ? playbackClock : null;
+  if (!activePlaybackClock) {
+    return freshForwardedClock;
+  }
+
+  const sameIdentity = clocksHaveSameIdentity(freshForwardedClock, activePlaybackClock);
+  const forwardedIsCurrentEnough =
+    freshForwardedClock.updatedAtMs >= activePlaybackClock.updatedAtMs ||
+    freshForwardedClock.state === activePlaybackClock.state;
+
+  return sameIdentity && forwardedIsCurrentEnough ? freshForwardedClock : activePlaybackClock;
+};
+
 const getEstimatedPlainLyricIndex = (lines: LyricLine[], positionMs: number, durationMs: number): number => {
   if (!lines.length) {
     return -1;
@@ -485,6 +577,29 @@ const getActiveIndex = (lyrics: DesktopLyricsStateSnapshot, clock: PlaybackClock
 
 const lineText = (line: LyricLine | null | undefined): string => line?.text.trim() ?? '';
 
+const clampUnit = (value: number): number => Math.max(0, Math.min(1, value));
+
+export const getDesktopLyricsLineProgress = (
+  lines: LyricLine[],
+  activeIndex: number,
+  clock: PlaybackClock | null,
+  offsetMs: number,
+): number => {
+  if (!clock || activeIndex < 0 || activeIndex >= lines.length) {
+    return 0;
+  }
+
+  const currentLine = lines[activeIndex];
+  const lineStartMs = currentLine.timeMs + offsetMs;
+  const nextLineStartMs = lines[activeIndex + 1]?.timeMs;
+  const lineEndMs = nextLineStartMs === undefined
+    ? Math.min(clock.durationMs || lineStartMs + 6_000, lineStartMs + 6_000)
+    : nextLineStartMs + offsetMs;
+  const durationMs = Math.max(1, lineEndMs - lineStartMs);
+
+  return clampUnit((getInterpolatedPositionMs(clock) - lineStartMs) / durationMs);
+};
+
 const clockIdentity = (clock: PlaybackClock | null): string | null =>
   clock?.currentTrackId ?? clock?.filePath ?? null;
 
@@ -505,52 +620,112 @@ const summarizeClockForLyricsLog = (clock: PlaybackClock | null): Record<string,
       }
     : null;
 
+type DesktopLyricsSecondaryText = {
+  kind: 'romanization' | 'translation' | 'status';
+  text: string;
+};
+
 const secondaryLineTexts = (
   line: LyricLine | null | undefined,
   showRomanization: boolean,
   showTranslation: boolean,
-): string[] => {
+): DesktopLyricsSecondaryText[] => {
   const romanization = showRomanization ? line?.romanization?.trim() : '';
   const translation = showTranslation ? line?.translation?.trim() : '';
-  return [romanization, translation].filter((text): text is string => Boolean(text));
+  const texts: Array<DesktopLyricsSecondaryText | null> = [
+    romanization ? { kind: 'romanization' as const, text: romanization } : null,
+    translation ? { kind: 'translation' as const, text: translation } : null,
+  ];
+  return texts.filter((text): text is DesktopLyricsSecondaryText => text !== null);
+};
+
+const renderDesktopLyricsRomanizationText = (text: string): JSX.Element => {
+  const tokens = text.trim().split(/\s+/u).filter(Boolean);
+  return (
+    <span className="desktop-lyrics-romanization-text">
+      {tokens.map((token, index) => (
+        <span className="desktop-lyrics-romanization-token" key={`${index}-${token}`}>
+          <VerticalText className="desktop-lyrics-romanization-character" text={token} />
+        </span>
+      ))}
+    </span>
+  );
+};
+
+const renderDesktopLyricsText = (
+  text: string,
+  isVerticalText: boolean,
+  kind: DesktopLyricsSecondaryText['kind'] | 'primary' = 'primary',
+): JSX.Element | string =>
+  isVerticalText
+    ? (
+        <span className="desktop-lyrics-scroll-clip">
+          <span className="desktop-lyrics-scroll-track">
+            {kind === 'romanization'
+              ? renderDesktopLyricsRomanizationText(text)
+              : <VerticalText className="desktop-lyrics-upright-character" text={text} />}
+          </span>
+        </span>
+      )
+    : text;
+
+const applyDesktopLyricsVerticalScrollProgress = (
+  lineTextElement: HTMLElement | null,
+  progress: number,
+): void => {
+  if (!lineTextElement) {
+    return;
+  }
+
+  const clampedProgress = clampUnit(progress);
+  lineTextElement.style.setProperty('--desktop-lyrics-line-progress', clampedProgress.toFixed(4));
+
+  for (const clip of Array.from(lineTextElement.querySelectorAll<HTMLElement>('.desktop-lyrics-scroll-clip'))) {
+    const track = clip.querySelector<HTMLElement>('.desktop-lyrics-scroll-track');
+    if (!track) {
+      continue;
+    }
+
+    const overflowPx = Number(clip.dataset.overflowPx ?? 0);
+    const offsetPx = Number.isFinite(overflowPx) && overflowPx > 1
+      ? -(overflowPx * clampedProgress)
+      : 0;
+    track.style.setProperty('--desktop-lyrics-scroll-offset', `${offsetPx.toFixed(2)}px`);
+  }
 };
 
 export const DesktopLyricsApp = (): JSX.Element => {
   const t = useOptionalI18n()?.t ?? translateFallback;
   const [settings, setSettings] = useState<DesktopLyricsSettings>(fallbackSettings);
   const [playbackClock, setPlaybackClock] = useState<PlaybackClock | null>(null);
+  const [playbackClockPriorityUntilMs, setPlaybackClockPriorityUntilMs] = useState(0);
   const [forwardedClock, setForwardedClock] = useState<PlaybackClock | null>(null);
   const [forwardedLyricsMetadata, setForwardedLyricsMetadata] = useState<ForwardedLyricsMetadata | null>(null);
   const [forwardedUpdatedAtMs, setForwardedUpdatedAtMs] = useState(0);
   const [lyrics, setLyrics] = useState<DesktopLyricsStateSnapshot>(() => emptyLyrics());
   const [lyricsRefreshToken, setLyricsRefreshToken] = useState(0);
   const [activeIndex, setActiveIndex] = useState(-1);
-  const [viewportWidthPx, setViewportWidthPx] = useState(() => window.innerWidth);
+  const [viewportSizePx, setViewportSizePx] = useState(() => ({
+    width: window.innerWidth,
+    height: window.innerHeight,
+  }));
   const [enhancedLowLoadPlaybackActive, setEnhancedLowLoadPlaybackActive] = useState(false);
   const [menuVisible, setMenuVisible] = useState(false);
   const lyricsRequestRef = useRef(0);
   const animationFrameRef = useRef<number | null>(null);
   const lastActiveClockLogRef = useRef<{ key: string; positionMs: number } | null>(null);
+  const lineTextRef = useRef<HTMLDivElement | null>(null);
 
-  const activeClock = useMemo(() => {
-    const forwardedClockFresh =
-      forwardedClock &&
-      clockHasIdentity(forwardedClock) &&
-      performance.now() - forwardedUpdatedAtMs <= forwardedStatusMaxAgeMs;
-
-    if (isActiveClock(playbackClock) && playbackClock?.source === 'connect') {
-      return playbackClock;
-    }
-
-    if (
-      forwardedClockFresh &&
-      (!isActiveClock(playbackClock) || clocksHaveSameIdentity(forwardedClock, playbackClock))
-    ) {
-      return forwardedClock;
-    }
-
-    return playbackClock;
-  }, [forwardedClock, forwardedUpdatedAtMs, playbackClock]);
+  const activeClock = useMemo(
+    () => selectDesktopLyricsActiveClock({
+      forwardedClock,
+      forwardedUpdatedAtMs,
+      nowMs: performance.now(),
+      playbackClock,
+      playbackClockPriorityUntilMs,
+    }),
+    [forwardedClock, forwardedUpdatedAtMs, playbackClock, playbackClockPriorityUntilMs],
+  );
 
   const activeTrackId = activeClock?.currentTrackId ?? null;
   const activeForwardedLyricsMetadata = useMemo(() => {
@@ -631,9 +806,12 @@ export const DesktopLyricsApp = (): JSX.Element => {
   }, []);
 
   useEffect(() => {
-    const updateViewportWidth = (): void => setViewportWidthPx(window.innerWidth);
-    window.addEventListener('resize', updateViewportWidth);
-    return () => window.removeEventListener('resize', updateViewportWidth);
+    const updateViewportSize = (): void => setViewportSizePx({
+      width: window.innerWidth,
+      height: window.innerHeight,
+    });
+    window.addEventListener('resize', updateViewportSize);
+    return () => window.removeEventListener('resize', updateViewportSize);
   }, []);
 
   useEffect(() => {
@@ -745,8 +923,22 @@ export const DesktopLyricsApp = (): JSX.Element => {
     };
     const updatePassthrough = (event: MouseEvent): void => {
       const target = document.elementFromPoint(event.clientX, event.clientY);
-      const overMenuRevealSurface = Boolean(target?.closest(desktopLyricsMenuRevealSelector));
-      const overInteractiveSurface = Boolean(target?.closest(desktopLyricsMouseInteractiveSelector));
+      const overMenuRevealSurface =
+        Boolean(target?.closest(desktopLyricsMenuRevealSelector)) ||
+        isPointInsideAnyElementRect(
+          event.clientX,
+          event.clientY,
+          desktopLyricsMenuRevealSelector,
+          desktopLyricsPointerHitPaddingPx,
+        );
+      const overInteractiveSurface =
+        Boolean(target?.closest(desktopLyricsMouseInteractiveSelector)) ||
+        isPointInsideAnyElementRect(
+          event.clientX,
+          event.clientY,
+          desktopLyricsMouseInteractiveSelector,
+          desktopLyricsPointerHitPaddingPx,
+        );
       updateMenuVisible(overMenuRevealSurface, !overMenuRevealSurface);
       setPassthrough(!overInteractiveSurface);
     };
@@ -987,6 +1179,10 @@ export const DesktopLyricsApp = (): JSX.Element => {
 
     const sync = (): void => {
       const nextIndex = getActiveIndex(lyrics, activeClock);
+      applyDesktopLyricsVerticalScrollProgress(
+        lineTextRef.current,
+        getDesktopLyricsLineProgress(lyrics.lines, nextIndex, activeClock, lyrics.offsetMs),
+      );
       setActiveIndex((current) => {
         if (current === nextIndex) {
           return current;
@@ -1045,7 +1241,7 @@ export const DesktopLyricsApp = (): JSX.Element => {
         setSettings(pickDesktopLyricsSettings(state.settings));
       }
     } catch {
-      setSettings((current) => current);
+      // Keep the optimistic local style when the desktop lyrics IPC call fails.
     }
   }, []);
 
@@ -1056,7 +1252,7 @@ export const DesktopLyricsApp = (): JSX.Element => {
         setSettings(pickDesktopLyricsSettings(state.settings));
       }
     } catch {
-      setSettings((current) => current);
+      // Keep the current lock state if the desktop lyrics IPC call fails.
     }
   }, []);
 
@@ -1072,7 +1268,7 @@ export const DesktopLyricsApp = (): JSX.Element => {
         setSettings(pickDesktopLyricsSettings(state.settings));
       }
     } catch {
-      setSettings((current) => current);
+      // Keep the current lock state if the desktop lyrics IPC call fails.
     }
   }, [settings.desktopLyricsLocked]);
 
@@ -1083,6 +1279,63 @@ export const DesktopLyricsApp = (): JSX.Element => {
   const resetBounds = useCallback((): void => {
     void window.echo?.desktopLyrics?.resetBounds?.();
   }, []);
+  const togglePlayback = useCallback(async (): Promise<void> => {
+    const commandClock = activeClock;
+    const commandStartedAtMs = performance.now();
+    const isPlaying = commandClock?.state === 'playing';
+    const optimisticClock = commandClock && clockHasIdentity(commandClock)
+      ? {
+          ...commandClock,
+          source: commandClock.source === 'connect' ? 'connect' : 'playback',
+          state: isPlaying ? 'paused' : 'playing',
+          positionMs: Math.round(getInterpolatedPositionMs(commandClock)),
+          updatedAtMs: commandStartedAtMs,
+          nativePositionStalenessMs: null,
+          nativeBufferedMs: null,
+          nativeUnderrunCallbacks: undefined,
+        } satisfies PlaybackClock
+      : null;
+
+    if (optimisticClock) {
+      setPlaybackClock(optimisticClock);
+      setPlaybackClockPriorityUntilMs(commandStartedAtMs + desktopLyricsPlaybackCommandPriorityMs);
+    }
+
+    try {
+      if (commandClock?.source === 'connect' && window.echo?.connect) {
+        const status = isPlaying
+          ? await window.echo.connect.pause()
+          : await window.echo.connect.play();
+        const connectClock = hqPlayerConnectStatusToDesktopLyricsClock(status, performance.now());
+        if (connectClock) {
+          setPlaybackClock(connectClock);
+        }
+        return;
+      }
+
+      const status = isPlaying
+        ? await window.echo?.playback?.pause?.()
+        : await window.echo?.playback?.play?.();
+      if (status) {
+        const updatedAtMs = performance.now();
+        let nextClock = playbackStatusToClock(status, updatedAtMs);
+        if (!isPlaying && optimisticClock && nextClock.state === 'playing' && clocksHaveSameIdentity(nextClock, optimisticClock)) {
+          const optimisticPositionMs = Math.round(getInterpolatedPositionMs(optimisticClock));
+          if (nextClock.positionMs + 120 < optimisticPositionMs) {
+            nextClock = {
+              ...nextClock,
+              positionMs: optimisticPositionMs,
+            };
+          }
+        }
+        setPlaybackClock(nextClock);
+        setPlaybackClockPriorityUntilMs(updatedAtMs + desktopLyricsPlaybackCommandPriorityMs);
+      }
+    } catch {
+      setPlaybackClockPriorityUntilMs(0);
+      void refreshPlaybackClock();
+    }
+  }, [activeClock, refreshPlaybackClock]);
   const handleMenuFocus = useCallback((): void => {
     setMenuVisible(true);
   }, []);
@@ -1110,7 +1363,10 @@ export const DesktopLyricsApp = (): JSX.Element => {
     ? []
     : lineText(currentLine)
       ? secondaryTexts
-      : [clockHasIdentity(activeClock) ? 'Desktop Lyrics' : t('desktopLyrics.secondary.waiting')];
+      : [{
+          kind: 'status' as const,
+          text: clockHasIdentity(activeClock) ? 'Desktop Lyrics' : t('desktopLyrics.secondary.waiting'),
+        }];
   const desktopLyricsFontFamily = [
     serializeFontList(settings.desktopLyricsFontFamily),
     '"Noto Sans SC"',
@@ -1118,25 +1374,111 @@ export const DesktopLyricsApp = (): JSX.Element => {
     '"Segoe UI"',
     'sans-serif',
   ].join(', ');
-  const availableTextWidthPx = Math.max(0, viewportWidthPx - desktopLyricsStageHorizontalPaddingPx);
-  const primaryTextFitScale = getDesktopLyricsTextFitScale({
+  const isVerticalText = settings.desktopLyricsTextDirection === 'vertical';
+  const availableTextWidthPx = Math.max(0, viewportSizePx.width - desktopLyricsStageHorizontalPaddingPx);
+  const availableTextHeightPx = Math.max(0, viewportSizePx.height - 20);
+  const visibleFittingSecondaryTexts = isVerticalText
+    ? visibleSecondaryTexts
+    : visibleSecondaryTexts.filter(({ text }) =>
+      shouldShowDesktopLyricsText({
+        text,
+        availableWidthPx: availableTextWidthPx,
+        availableHeightPx: availableTextHeightPx,
+        fontSizePx: settings.desktopLyricsFontSizePx * 0.56,
+        fontFamily: desktopLyricsFontFamily,
+        fontWeight: 600,
+        scalePercent: settings.desktopLyricsScalePercent,
+        textDirection: settings.desktopLyricsTextDirection,
+      }),
+    );
+  const visibleSecondaryTextKey = visibleFittingSecondaryTexts
+    .map(({ kind, text }) => `${kind}:${text}`)
+    .join('\n');
+  useLayoutEffect(() => {
+    if (!isVerticalText) {
+      return undefined;
+    }
+
+    const lineTextElement = lineTextRef.current;
+    if (!lineTextElement) {
+      return undefined;
+    }
+
+    let frameId: number | null = null;
+    const measure = (): void => {
+      frameId = null;
+      const progress = getDesktopLyricsLineProgress(lyrics.lines, activeIndex, activeClock, lyrics.offsetMs);
+      for (const clip of Array.from(lineTextElement.querySelectorAll<HTMLElement>('.desktop-lyrics-scroll-clip'))) {
+        const track = clip.querySelector<HTMLElement>('.desktop-lyrics-scroll-track');
+        if (!track) {
+          continue;
+        }
+
+        const overflowPx = Math.max(0, track.scrollHeight - clip.clientHeight);
+        clip.dataset.overflow = overflowPx > 1 ? 'true' : 'false';
+        clip.dataset.overflowPx = `${Math.ceil(overflowPx)}`;
+        clip.style.setProperty('--desktop-lyrics-scroll-overflow', `${Math.ceil(overflowPx)}px`);
+      }
+      applyDesktopLyricsVerticalScrollProgress(lineTextElement, progress);
+    };
+    const scheduleMeasure = (): void => {
+      if (frameId !== null) {
+        return;
+      }
+      frameId = window.requestAnimationFrame(measure);
+    };
+
+    scheduleMeasure();
+
+    const ResizeObserverCtor = window.ResizeObserver;
+    if (!ResizeObserverCtor) {
+      window.addEventListener('resize', scheduleMeasure);
+      return () => {
+        if (frameId !== null) {
+          window.cancelAnimationFrame(frameId);
+        }
+        window.removeEventListener('resize', scheduleMeasure);
+      };
+    }
+
+    const observer = new ResizeObserverCtor(scheduleMeasure);
+    observer.observe(lineTextElement);
+    for (const element of Array.from(lineTextElement.querySelectorAll('.desktop-lyrics-scroll-clip, .desktop-lyrics-scroll-track'))) {
+      observer.observe(element);
+    }
+
+    return () => {
+      if (frameId !== null) {
+        window.cancelAnimationFrame(frameId);
+      }
+      observer.disconnect();
+    };
+  }, [
+    isVerticalText,
+    activeClock,
+    activeIndex,
+    lyrics.lines,
+    lyrics.offsetMs,
+    primaryText,
+    settings.desktopLyricsFontFamily,
+    settings.desktopLyricsFontSizePx,
+    settings.desktopLyricsScalePercent,
+    visibleSecondaryTextKey,
+    viewportSizePx.height,
+  ]);
+  const desktopLyricsTextFitScale = getDesktopLyricsTextFitScale({
     text: primaryText,
     availableWidthPx: availableTextWidthPx,
+    availableHeightPx: availableTextHeightPx,
     fontSizePx: settings.desktopLyricsFontSizePx,
     fontFamily: desktopLyricsFontFamily,
     fontWeight: 700,
     scalePercent: settings.desktopLyricsScalePercent,
+    textDirection: settings.desktopLyricsTextDirection,
   });
-  const visibleFittingSecondaryTexts = visibleSecondaryTexts.filter((text) =>
-    shouldShowDesktopLyricsText({
-      text,
-      availableWidthPx: availableTextWidthPx,
-      fontSizePx: settings.desktopLyricsFontSizePx * 0.56,
-      fontFamily: desktopLyricsFontFamily,
-      fontWeight: 600,
-      scalePercent: settings.desktopLyricsScalePercent,
-    }),
-  );
+  const desktopLyricsLineProgress = isVerticalText
+    ? getDesktopLyricsLineProgress(lyrics.lines, activeIndex, activeClock, lyrics.offsetMs)
+    : 0;
   const desktopLyricsColor =
     settings.desktopLyricsColorMode === 'custom'
       ? settings.desktopLyricsColor
@@ -1154,8 +1496,9 @@ export const DesktopLyricsApp = (): JSX.Element => {
     '--desktop-lyrics-stroke-color': desktopLyricsStrokeColor,
     '--desktop-lyrics-opacity': (settings.desktopLyricsOpacityPercent / 100).toFixed(2),
   } as CSSProperties;
-  const primaryTextStyle = {
-    '--desktop-lyrics-text-fit-scale': primaryTextFitScale.toFixed(3),
+  const lineTextStyle = {
+    '--desktop-lyrics-text-fit-scale': desktopLyricsTextFitScale.toFixed(3),
+    '--desktop-lyrics-line-progress': desktopLyricsLineProgress.toFixed(4),
   } as CSSProperties;
 
   return (
@@ -1164,18 +1507,38 @@ export const DesktopLyricsApp = (): JSX.Element => {
       data-color-mode={settings.desktopLyricsColorMode}
       data-locked={settings.desktopLyricsLocked}
       data-menu-visible={menuVisible}
+      data-playback-state={activeClock?.state ?? 'stopped'}
+      data-text-direction={settings.desktopLyricsTextDirection}
       style={style}
     >
       <section className="desktop-lyrics-stage" aria-label={t('desktopLyrics.aria.stage')}>
         <div className="desktop-lyrics-lines" onContextMenu={(event) => void unlockFromContextMenu(event)}>
-          <strong style={primaryTextStyle}>{primaryText}</strong>
-          {visibleFittingSecondaryTexts.map((text, index) => (
-            <span key={`${index}-${text}`}>{text}</span>
-          ))}
+          <div className="desktop-lyrics-line-text" ref={lineTextRef} style={lineTextStyle}>
+            <strong aria-label={isVerticalText ? primaryText : undefined}>
+              {renderDesktopLyricsText(primaryText, isVerticalText)}
+            </strong>
+            {visibleFittingSecondaryTexts.map(({ kind, text }, index) => (
+              <span
+                data-secondary-kind={kind}
+                key={`${kind}-${index}-${text}`}
+                aria-label={isVerticalText ? text : undefined}
+              >
+                {renderDesktopLyricsText(text, isVerticalText, kind)}
+              </span>
+            ))}
+          </div>
         </div>
 
         {!settings.desktopLyricsLocked ? (
           <div className="desktop-lyrics-menu" onBlur={handleMenuBlur} onFocus={handleMenuFocus}>
+            <button
+              type="button"
+              title={t(activeClock?.state === 'playing' ? 'desktopLyrics.control.pause' : 'desktopLyrics.control.play')}
+              aria-label={t(activeClock?.state === 'playing' ? 'desktopLyrics.control.pause' : 'desktopLyrics.control.play')}
+              onClick={() => void togglePlayback()}
+            >
+              {activeClock?.state === 'playing' ? <Pause size={14} /> : <Play size={14} />}
+            </button>
             <button
               type="button"
               title={t('desktopLyrics.control.decreaseFontSize')}
@@ -1209,6 +1572,17 @@ export const DesktopLyricsApp = (): JSX.Element => {
               onClick={() => void patchStyle({ desktopLyricsScalePercent: settings.desktopLyricsScalePercent + 5 })}
             >
               <Plus size={14} />
+            </button>
+            <button
+              className="desktop-lyrics-menu-toggle"
+              type="button"
+              title={t('desktopLyrics.control.textDirection')}
+              aria-label={t('desktopLyrics.control.textDirection')}
+              aria-pressed={isVerticalText}
+              onClick={() =>
+                void patchStyle({ desktopLyricsTextDirection: isVerticalText ? 'horizontal' : 'vertical' })}
+            >
+              <Rows3 size={14} />
             </button>
             <Palette size={15} aria-hidden="true" />
             <div className="desktop-lyrics-swatches">

--- a/src/renderer/i18n/locales.ts
+++ b/src/renderer/i18n/locales.ts
@@ -597,9 +597,12 @@ export type TranslationKey =
   | 'desktopLyrics.control.increaseFontSize'
   | 'desktopLyrics.control.increaseScale'
   | 'desktopLyrics.control.lock'
+  | 'desktopLyrics.control.pause'
+  | 'desktopLyrics.control.play'
   | 'desktopLyrics.control.resetPosition'
   | 'desktopLyrics.control.romanization'
   | 'desktopLyrics.control.themeColor'
+  | 'desktopLyrics.control.textDirection'
   | 'desktopLyrics.control.translation'
   | 'desktopLyrics.control.translationShort'
   | 'desktopLyrics.primary.empty'
@@ -1464,6 +1467,7 @@ export type TranslationKey =
   | 'lyricsSettings.display.desktopOpacity'
   | 'lyricsSettings.display.desktopOpacityDescription'
   | 'lyricsSettings.display.desktopRomanization'
+  | 'lyricsSettings.display.desktopTextDirection'
   | 'lyricsSettings.display.desktopTranslation'
   | 'lyricsSettings.display.disableMvTrackInfoAutoShow'
   | 'lyricsSettings.display.enableLyrics'
@@ -1500,6 +1504,8 @@ export type TranslationKey =
   | 'lyricsSettings.drawer.aria'
   | 'lyricsSettings.drawer.close'
   | 'lyricsSettings.drawer.title'
+  | 'lyricsSettings.direction.horizontal'
+  | 'lyricsSettings.direction.vertical'
   | 'lyricsSettings.engine.autoMatch'
   | 'lyricsSettings.engine.provider'
   | 'lyricsSettings.engine.threshold'
@@ -1571,6 +1577,7 @@ export type TranslationKey =
   | 'lyricsSettings.style.secondaryFontSize'
   | 'lyricsSettings.style.showControls'
   | 'lyricsSettings.style.showControlsDescription'
+  | 'lyricsSettings.style.textDirection'
   | 'lyricsSettings.style.useColor'
   | 'lyricsSettings.timing.defaultOffset'
   | 'lyricsSettings.timing.globalOffset'
@@ -3386,9 +3393,12 @@ const zhCN: TranslationMap = {
   'desktopLyrics.control.increaseFontSize': '增大字号',
   'desktopLyrics.control.increaseScale': '放大',
   'desktopLyrics.control.lock': '锁定',
+  'desktopLyrics.control.pause': '暂停',
+  'desktopLyrics.control.play': '播放',
   'desktopLyrics.control.resetPosition': '重置位置',
   'desktopLyrics.control.romanization': '桌面歌词显示罗马音',
   'desktopLyrics.control.themeColor': '跟随主题颜色',
+  'desktopLyrics.control.textDirection': '切换横排 / 竖排',
   'desktopLyrics.control.translation': '桌面歌词显示翻译',
   'desktopLyrics.control.translationShort': '译',
   'desktopLyrics.primary.empty': '暂无歌词',
@@ -4568,6 +4578,7 @@ const zhCN: TranslationMap = {
   'lyricsSettings.display.desktopOpacity': '桌面歌词透明度',
   'lyricsSettings.display.desktopOpacityDescription': '当前 {opacity}%，调低可减少遮挡。',
   'lyricsSettings.display.desktopRomanization': '桌面歌词显示罗马音',
+  'lyricsSettings.display.desktopTextDirection': '桌面歌词排版',
   'lyricsSettings.display.desktopTranslation': '桌面歌词显示翻译',
   'lyricsSettings.display.disableMvTrackInfoAutoShow': '关闭MV自动显示歌曲信息',
   'lyricsSettings.display.enableLyrics': '启用歌词',
@@ -4604,6 +4615,8 @@ const zhCN: TranslationMap = {
   'lyricsSettings.drawer.aria': '歌词设置',
   'lyricsSettings.drawer.close': '关闭歌词设置',
   'lyricsSettings.drawer.title': '歌词设置',
+  'lyricsSettings.direction.horizontal': '横排',
+  'lyricsSettings.direction.vertical': '竖排',
   'lyricsSettings.engine.autoMatch': '自动匹配',
   'lyricsSettings.engine.provider': '来源',
   'lyricsSettings.engine.threshold': '阈值',
@@ -4674,7 +4687,8 @@ const zhCN: TranslationMap = {
   'lyricsSettings.style.lyricsFont': '歌词字体',
   'lyricsSettings.style.secondaryFontSize': '辅歌词字号',
   'lyricsSettings.style.showControls': '显示歌词样式设置',
-  'lyricsSettings.style.showControlsDescription': '包含辅助字号、歌词字号、歌词行距、上下文透明度和歌词颜色。',
+  'lyricsSettings.style.showControlsDescription': '包含排版方向、辅助字号、歌词字号、歌词行距、上下文透明度和歌词颜色。',
+  'lyricsSettings.style.textDirection': '歌词排版',
   'lyricsSettings.style.useColor': '使用颜色 {color}',
   'lyricsSettings.timing.defaultOffset': '新歌词默认延迟',
   'lyricsSettings.timing.globalOffset': '全局延迟',
@@ -6475,9 +6489,12 @@ const zhTW: TranslationMap = {
   'desktopLyrics.control.increaseFontSize': '放大字號',
   'desktopLyrics.control.increaseScale': '放大',
   'desktopLyrics.control.lock': '鎖定',
+  'desktopLyrics.control.pause': '暫停',
+  'desktopLyrics.control.play': '播放',
   'desktopLyrics.control.resetPosition': '重設位置',
   'desktopLyrics.control.romanization': '桌面歌詞顯示羅馬音',
   'desktopLyrics.control.themeColor': '跟隨主題顏色',
+  'desktopLyrics.control.textDirection': '切換橫排 / 直排',
   'desktopLyrics.control.translation': '桌面歌詞顯示翻譯',
   'desktopLyrics.control.translationShort': '譯',
   'desktopLyrics.primary.empty': '暫無歌詞',
@@ -7589,6 +7606,7 @@ const zhTW: TranslationMap = {
   'lyricsSettings.display.desktopOpacity': '桌面歌詞透明度',
   'lyricsSettings.display.desktopOpacityDescription': '目前 {opacity}%，調低可減少遮擋。',
   'lyricsSettings.display.desktopRomanization': '桌面歌詞顯示羅馬音',
+  'lyricsSettings.display.desktopTextDirection': '桌面歌詞排版',
   'lyricsSettings.display.desktopTranslation': '桌面歌詞顯示翻譯',
   'lyricsSettings.display.disableMvTrackInfoAutoShow': '關閉 MV 自動顯示歌曲資訊',
   'lyricsSettings.display.enableLyrics': '啟用歌詞',
@@ -7625,6 +7643,8 @@ const zhTW: TranslationMap = {
   'lyricsSettings.drawer.aria': '歌詞設定',
   'lyricsSettings.drawer.close': '關閉歌詞設定',
   'lyricsSettings.drawer.title': '歌詞設定',
+  'lyricsSettings.direction.horizontal': '橫排',
+  'lyricsSettings.direction.vertical': '直排',
   'lyricsSettings.engine.autoMatch': '自動匹配',
   'lyricsSettings.engine.provider': '來源',
   'lyricsSettings.engine.threshold': '閾值',
@@ -7695,7 +7715,8 @@ const zhTW: TranslationMap = {
   'lyricsSettings.style.lyricsFont': '歌詞字體',
   'lyricsSettings.style.secondaryFontSize': '輔助歌詞字號',
   'lyricsSettings.style.showControls': '顯示歌詞樣式設定',
-  'lyricsSettings.style.showControlsDescription': '包含輔助字號、歌詞字號、歌詞行距、上下文透明度和歌詞顏色。',
+  'lyricsSettings.style.showControlsDescription': '包含排版方向、輔助字號、歌詞字號、歌詞行距、上下文透明度和歌詞顏色。',
+  'lyricsSettings.style.textDirection': '歌詞排版',
   'lyricsSettings.style.useColor': '使用顏色 {color}',
   'lyricsSettings.timing.defaultOffset': '新歌詞預設延遲',
   'lyricsSettings.timing.globalOffset': '全域延遲',
@@ -9315,9 +9336,12 @@ const jaJP: TranslationMap = {
   'desktopLyrics.control.increaseFontSize': '文字サイズを大きく',
   'desktopLyrics.control.increaseScale': '拡大',
   'desktopLyrics.control.lock': 'ロック',
+  'desktopLyrics.control.pause': '一時停止',
+  'desktopLyrics.control.play': '再生',
   'desktopLyrics.control.resetPosition': '位置をリセット',
   'desktopLyrics.control.romanization': 'デスクトップ歌詞にローマ字を表示',
   'desktopLyrics.control.themeColor': 'テーマ色に合わせる',
+  'desktopLyrics.control.textDirection': '横書き / 縦書きを切り替え',
   'desktopLyrics.control.translation': 'デスクトップ歌詞に翻訳を表示',
   'desktopLyrics.control.translationShort': '訳',
   'desktopLyrics.primary.empty': '歌詞がありません',
@@ -10445,6 +10469,7 @@ const jaJP: TranslationMap = {
   'lyricsSettings.display.desktopOpacity': 'デスクトップ歌詞の透明度',
   'lyricsSettings.display.desktopOpacityDescription': '現在 {opacity}%。下げると画面を遮りにくくなります。',
   'lyricsSettings.display.desktopRomanization': 'デスクトップ歌詞にローマ字を表示',
+  'lyricsSettings.display.desktopTextDirection': 'デスクトップ歌詞の組み方向',
   'lyricsSettings.display.desktopTranslation': 'デスクトップ歌詞に翻訳を表示',
   'lyricsSettings.display.disableMvTrackInfoAutoShow': 'MV で曲情報を自動表示しない',
   'lyricsSettings.display.enableLyrics': '歌詞を有効化',
@@ -10481,6 +10506,8 @@ const jaJP: TranslationMap = {
   'lyricsSettings.drawer.aria': '歌詞設定',
   'lyricsSettings.drawer.close': '歌詞設定を閉じる',
   'lyricsSettings.drawer.title': '歌詞設定',
+  'lyricsSettings.direction.horizontal': '横書き',
+  'lyricsSettings.direction.vertical': '縦書き',
   'lyricsSettings.engine.autoMatch': '自動マッチ',
   'lyricsSettings.engine.provider': 'ソース',
   'lyricsSettings.engine.threshold': 'しきい値',
@@ -10551,7 +10578,8 @@ const jaJP: TranslationMap = {
   'lyricsSettings.style.lyricsFont': '歌詞フォント',
   'lyricsSettings.style.secondaryFontSize': 'サブ歌詞フォントサイズ',
   'lyricsSettings.style.showControls': '歌詞スタイル設定を表示',
-  'lyricsSettings.style.showControlsDescription': 'サブ歌詞サイズ、歌詞サイズ、行間、前後行の透明度、歌詞色を含みます。',
+  'lyricsSettings.style.showControlsDescription': '組み方向、サブ歌詞サイズ、歌詞サイズ、行間、前後行の透明度、歌詞色を含みます。',
+  'lyricsSettings.style.textDirection': '歌詞の組み方向',
   'lyricsSettings.style.useColor': '色 {color} を使用',
   'lyricsSettings.timing.defaultOffset': '新しい歌詞の既定遅延',
   'lyricsSettings.timing.globalOffset': '全体遅延',
@@ -12236,9 +12264,12 @@ const enUS: TranslationMap = {
   'desktopLyrics.control.increaseFontSize': 'Increase font size',
   'desktopLyrics.control.increaseScale': 'Scale up',
   'desktopLyrics.control.lock': 'Lock',
+  'desktopLyrics.control.pause': 'Pause',
+  'desktopLyrics.control.play': 'Play',
   'desktopLyrics.control.resetPosition': 'Reset position',
   'desktopLyrics.control.romanization': 'Show romanization in desktop lyrics',
   'desktopLyrics.control.themeColor': 'Follow theme color',
+  'desktopLyrics.control.textDirection': 'Toggle horizontal / vertical',
   'desktopLyrics.control.translation': 'Show translation in desktop lyrics',
   'desktopLyrics.control.translationShort': 'T',
   'desktopLyrics.primary.empty': 'No lyrics',
@@ -13366,6 +13397,7 @@ const enUS: TranslationMap = {
   'lyricsSettings.display.desktopOpacity': 'Desktop lyrics opacity',
   'lyricsSettings.display.desktopOpacityDescription': 'Currently {opacity}%; lower it to reduce visual blocking.',
   'lyricsSettings.display.desktopRomanization': 'Show romanization in desktop lyrics',
+  'lyricsSettings.display.desktopTextDirection': 'Desktop lyrics direction',
   'lyricsSettings.display.desktopTranslation': 'Show translation in desktop lyrics',
   'lyricsSettings.display.disableMvTrackInfoAutoShow': 'Disable MV auto track info',
   'lyricsSettings.display.enableLyrics': 'Enable lyrics',
@@ -13402,6 +13434,8 @@ const enUS: TranslationMap = {
   'lyricsSettings.drawer.aria': 'Lyrics settings',
   'lyricsSettings.drawer.close': 'Close lyrics settings',
   'lyricsSettings.drawer.title': 'Lyrics Settings',
+  'lyricsSettings.direction.horizontal': 'Horizontal',
+  'lyricsSettings.direction.vertical': 'Vertical',
   'lyricsSettings.engine.autoMatch': 'Auto match',
   'lyricsSettings.engine.provider': 'Provider',
   'lyricsSettings.engine.threshold': 'Threshold',
@@ -13472,7 +13506,8 @@ const enUS: TranslationMap = {
   'lyricsSettings.style.lyricsFont': 'Lyrics font',
   'lyricsSettings.style.secondaryFontSize': 'Secondary lyrics font size',
   'lyricsSettings.style.showControls': 'Show lyrics style settings',
-  'lyricsSettings.style.showControlsDescription': 'Includes secondary font size, lyrics font size, line spacing, context opacity, and lyrics color.',
+  'lyricsSettings.style.showControlsDescription': 'Includes text direction, secondary font size, lyrics font size, line spacing, context opacity, and lyrics color.',
+  'lyricsSettings.style.textDirection': 'Lyrics direction',
   'lyricsSettings.style.useColor': 'Use color {color}',
   'lyricsSettings.timing.defaultOffset': 'Default offset for new lyrics',
   'lyricsSettings.timing.globalOffset': 'Global offset',

--- a/src/renderer/pages/LyricsPage.test.tsx
+++ b/src/renderer/pages/LyricsPage.test.tsx
@@ -150,6 +150,7 @@ const makeAppSettings = (
   lyricsUtatenKanaEnabled: false,
   lyricsTranslationEnabled: true,
   lyricsWordHighlightEnabled: true,
+  lyricsTextDirection: "horizontal",
   lyricsFontSizePx: 40,
   lyricsSecondaryFontSizePx: 22,
   lyricsLineSpacingPercent: 110,
@@ -467,10 +468,10 @@ describe("LyricsPage", () => {
     expect(css).toContain("color-mix(in srgb, var(--lyrics-word-fill-color) 72%, var(--lyrics-word-upcoming-color) 28%) calc(var(--lyrics-word-progress) * 100%)");
     expect(css).toContain('.lyrics-line[data-active="true"][data-word-highlight="true"] .lyrics-word[data-word-state="current"]');
     expect(css).toContain("--lyrics-word-upcoming-color: color-mix(in srgb, var(--lyrics-readable-color) var(--lyrics-current-word-clarity, 70%), transparent);");
-    expect(css).toMatch(/\.lyrics-line\[data-active="true"\] span \{[\s\S]*?line-height: 1\.18;/);
+    expect(css).toMatch(/\.lyrics-line\[data-active="true"\] \.lyrics-line-primary \{[\s\S]*?line-height: 1\.18;/);
     expect(css).not.toContain('scale(1.045)');
     expect(css).not.toContain('.lyrics-word[data-word-state="current"]::after');
-    expect(css).toContain('.lyrics-page:has(.lyrics-mv-panel[data-lyrics-readability="true"]) .lyrics-line span');
+    expect(css).toContain('.lyrics-page:has(.lyrics-mv-panel[data-lyrics-readability="true"]) .lyrics-line .lyrics-line-primary');
     expect(css).toContain('.lyrics-page:has(.lyrics-mv-panel[data-lyrics-readability="true"]) .lyrics-line[data-word-highlight="true"] .lyrics-word');
     expect(css).not.toMatch(/\.lyrics-page:has\(\.lyrics-mv-background\) \.lyrics-line(?:\[data-active="true"\])? \{\s*color: var\(--lyrics-color\);/);
   });
@@ -505,9 +506,9 @@ describe("LyricsPage", () => {
   it("keeps MV immersive lyrics on the normal lyrics size scale", () => {
     const css = readFileSync("src/renderer/styles/lyrics.css", "utf8");
 
-    expect(css).toMatch(/\.lyrics-page:has\(\.lyrics-mv-background\) \.lyrics-line span \{\s*max-width: min\(100%, 1120px, var\(--lyrics-line-max-width\)\);\s*font-size: calc\(var\(--lyrics-font-size\) \* 0\.9\);/);
-    expect(css).toMatch(/\.lyrics-line span \{\s*display: inline-block;\s*max-width: min\(100%, var\(--lyrics-line-max-width\)\);/);
-    expect(css).toMatch(/\.lyrics-page:has\(\.lyrics-mv-background\) \.lyrics-line\[data-active="true"\] span \{\s*font-size: calc\(var\(--lyrics-font-size\) \* 1\.25\);/);
+    expect(css).toMatch(/\.lyrics-page:has\(\.lyrics-mv-background\) \.lyrics-line \.lyrics-line-primary \{\s*max-width: min\(100%, 1120px, var\(--lyrics-line-max-width\)\);\s*font-size: calc\(var\(--lyrics-font-size\) \* 0\.9\);/);
+    expect(css).toMatch(/\.lyrics-line-primary \{\s*display: inline-block;\s*max-width: min\(100%, var\(--lyrics-line-max-width\)\);/);
+    expect(css).toMatch(/\.lyrics-page:has\(\.lyrics-mv-background\) \.lyrics-line\[data-active="true"\] \.lyrics-line-primary \{\s*font-size: calc\(var\(--lyrics-font-size\) \* 1\.25\);/);
     expect(css).not.toMatch(/\.lyrics-page:has\(\.lyrics-mv-background\)[\s\S]*font-size: calc\(var\(--lyrics-font-size\) \* 1\.5\);/);
   });
 
@@ -1586,7 +1587,7 @@ describe("LyricsPage", () => {
   it("does not seek when a synced lyric line is clicked", async () => {
     const track = makeTrack();
     const { seek } = mockEcho(track, 0);
-    render(
+    const { container } = render(
       <PlaybackQueueProvider>
         <QueueSeed track={track}>
           <LyricsPage initialLyrics={lyrics} />
@@ -1594,10 +1595,82 @@ describe("LyricsPage", () => {
       </PlaybackQueueProvider>,
     );
 
-    fireEvent.click(await screen.findByText("Second line"));
+    await waitFor(() => expect(container.querySelector(".lyrics-line-primary")?.textContent).toBe("First line"));
+    const secondLineButton = Array.from(container.querySelectorAll<HTMLButtonElement>(".lyrics-line"))
+      .find((line) => line.querySelector(".lyrics-line-primary")?.textContent === "Second line");
+    expect(secondLineButton).toBeTruthy();
+    fireEvent.click(secondLineButton!);
 
     expect(seek).not.toHaveBeenCalled();
     expect(document.querySelector('.lyrics-line[data-seekable="true"]')).toBeNull();
+    expect(container.querySelector(".lyrics-page")?.getAttribute("data-lyrics-text-direction")).toBe("horizontal");
+    expect(container.querySelector(".lyrics-scroll")?.getAttribute("data-text-direction")).toBe("horizontal");
+  });
+
+  it("applies vertical lyrics text direction without restoring lyric seek", async () => {
+    const track = makeTrack();
+    const { seek } = mockEcho(track, 0, { lyricsTextDirection: "vertical" });
+    const { container } = render(
+      <PlaybackQueueProvider>
+        <QueueSeed track={track}>
+          <LyricsPage initialLyrics={lyrics} />
+        </QueueSeed>
+      </PlaybackQueueProvider>,
+    );
+
+    await waitFor(() => expect(container.querySelector(".lyrics-line-primary")?.getAttribute("aria-label")).toBe("First line"));
+    const secondLineButton = Array.from(container.querySelectorAll<HTMLButtonElement>(".lyrics-line"))
+      .find((line) => line.querySelector(".lyrics-line-primary")?.getAttribute("aria-label") === "Second line");
+    expect(secondLineButton).toBeTruthy();
+    fireEvent.click(secondLineButton!);
+
+    expect(seek).not.toHaveBeenCalled();
+    expect(document.querySelector('.lyrics-line[data-seekable="true"]')).toBeNull();
+    expect(container.querySelector(".lyrics-page")?.getAttribute("data-lyrics-text-direction")).toBe("vertical");
+    expect(container.querySelector(".lyrics-scroll")?.getAttribute("data-text-direction")).toBe("vertical");
+  });
+
+  it("keeps primary, romanization, and translation grouped in vertical lyrics", async () => {
+    const track = makeTrack();
+    mockEcho(track, 0, { lyricsTextDirection: "vertical" });
+    const { container } = render(
+      <PlaybackQueueProvider>
+        <QueueSeed track={track}>
+          <LyricsPage
+            initialLyrics={[
+              {
+                timeMs: 0,
+                text: "らくになる日はまず来ない",
+                romanization: "ra ku ni na ru hi wa ma zu ko na i",
+                translation: "轻松的生活不会到来",
+              },
+            ]}
+          />
+        </QueueSeed>
+      </PlaybackQueueProvider>,
+    );
+
+    await waitFor(() => expect(container.querySelector(".lyrics-line-primary")?.textContent).toBe("らくになる日はまず来ない"));
+    const lineText = container.querySelector(".lyrics-line-text");
+
+    expect(container.querySelector(".lyrics-scroll")?.getAttribute("data-text-direction")).toBe("vertical");
+    expect(lineText?.querySelector(".lyrics-line-primary")?.textContent).toBe("らくになる日はまず来ない");
+    expect(lineText?.querySelector("small")?.getAttribute("aria-label")).toBe("ra ku ni na ru hi wa ma zu ko na i");
+    expect(lineText?.querySelector("small")?.textContent).toBe("rakuninaruhiwamazukonai");
+    expect(lineText?.querySelector("em")?.textContent).toBe("轻松的生活不会到来");
+    expect(lineText?.querySelectorAll(".lyrics-line-primary .lyrics-upright-character").length).toBe(
+      Array.from("らくになる日はまず来ない").length,
+    );
+    expect(lineText?.querySelectorAll("small .lyrics-upright-character[data-sideways=\"true\"]").length).toBeGreaterThan(0);
+  });
+
+  it("keeps vertical active lyrics on the normal primary size scale", () => {
+    const css = readFileSync("src/renderer/styles/lyrics.css", "utf8");
+
+    expect(css).toMatch(/\.lyrics-scroll\[data-text-direction="vertical"\] \.lyrics-line\[data-active="true"\] \.lyrics-line-primary,[\s\S]*?font-size: calc\(var\(--lyrics-font-size\) \* 1\.25\);[\s\S]*?font-weight: 850;/);
+    expect(css).toMatch(/\.lyrics-scroll\[data-text-direction="vertical"\] \.lyrics-line-text \{[\s\S]*?column-gap: clamp\(8px, 1\.4vw, 22px\);/);
+    expect(css).toMatch(/\.lyrics-scroll\[data-text-direction="vertical"\] \.lyrics-line-primary \{[\s\S]*?justify-content: center;/);
+    expect(css).toMatch(/\.lyrics-scroll\[data-text-direction="vertical"\] \.lyrics-line small,[\s\S]*?\.lyrics-scroll\[data-text-direction="vertical"\] \.lyrics-line em \{[\s\S]*?justify-content: center;/);
   });
 
   it("uses album artwork as the MV fallback and shows a default visual without cover art", async () => {
@@ -2138,9 +2211,9 @@ describe("LyricsPage", () => {
   });
 
   it.each([
-    ["exclusive", "WASAPI 独占"],
-    ["asio", "ASIO"],
-  ] as const)("auto-saves smart lyrics alignment from stable anchors on %s clocks", async (outputMode, modeLabel) => {
+    ["exclusive"],
+    ["asio"],
+  ] as const)("auto-saves smart lyrics alignment from stable anchors on %s clocks", async (outputMode) => {
     const track = makeTrack();
     const { emitAudioStatus } = mockEcho(track, 10.2, { lyricsSmartAlignmentEnabled: true });
     window.echo.lyrics = {
@@ -3932,6 +4005,7 @@ describe("LyricsPage", () => {
           lyricsLineSpacingPercent: 74,
           lyricsLineMaxChars: 28,
           lyricsContextOpacityPercent: 24,
+          lyricsTextDirection: "vertical",
         },
       }),
     );
@@ -3962,6 +4036,8 @@ describe("LyricsPage", () => {
     expect(page.style.getPropertyValue("--lyrics-context-opacity")).toBe(
       "0.24",
     );
+    expect(page.dataset.lyricsTextDirection).toBe("vertical");
+    expect(container.querySelector(".lyrics-scroll")?.getAttribute("data-text-direction")).toBe("vertical");
   });
 
   it("ignores explicit non-lyrics settings change events", async () => {
@@ -4022,13 +4098,14 @@ describe("LyricsPage", () => {
       clearCache: vi.fn(),
     };
 
-    render(
+    const renderResult = render(
       <PlaybackQueueProvider>
         <QueueSeed track={track}>
           <LyricsPage />
         </QueueSeed>
       </PlaybackQueueProvider>,
     );
+    const container = renderResult.container;
 
     expect(await screen.findByText("Stable current lyrics")).toBeTruthy();
     expect(window.echo.lyrics.getForTrack).toHaveBeenCalledTimes(1);
@@ -4040,11 +4117,14 @@ describe("LyricsPage", () => {
           lyricsFontSizePx: 48,
           lyricsLineSpacingPercent: 116,
           lyricsContextOpacityPercent: 70,
+          lyricsTextDirection: "vertical",
         },
       }),
     );
 
-    await waitFor(() => expect(screen.getByText("Stable current lyrics")).toBeTruthy());
+    await waitFor(() => {
+      expect(container.querySelector(".lyrics-line-primary")?.textContent).toBe("Stable current lyrics");
+    });
     expect(window.echo.lyrics.getForTrack).toHaveBeenCalledTimes(1);
     expect(window.echo.lyrics.searchCandidates).not.toHaveBeenCalled();
   });

--- a/src/renderer/pages/LyricsPage.tsx
+++ b/src/renderer/pages/LyricsPage.tsx
@@ -30,7 +30,6 @@ import type {
 import { neteaseDjRadioPlaylistPrefix, streamingProviderNames } from "../../shared/types/streaming";
 import type { PlaybackStatus } from "../../shared/types/playback";
 import { decodeTextFileBytes } from "../../shared/utils/decodeTextFile";
-import { shouldShowRomanizationForLyrics } from "../../shared/utils/lyricsLanguage";
 import { LyricsView, getActiveLyricIndex, getEstimatedPlainLyricIndex } from "../components/lyrics/LyricsView";
 import { MvPanel, type MvAudioClock } from "../components/lyrics/MvPanel";
 import {
@@ -56,7 +55,7 @@ import type { LyricLine, LyricsState } from "../components/lyrics/lyricsTypes";
 import { PlayerStatusChips } from "../components/player/PlayerStatusChips";
 import { titleFromPath } from "../components/player/playerFormat";
 import { usePlaybackQueue } from "../stores/PlaybackQueueProvider";
-import { beginPlaybackSeekSnapshot, refreshPlaybackStatus, setPlaybackStatusSnapshot, useSharedPlaybackStatus } from "../stores/playbackStatusStore";
+import { beginPlaybackSeekSnapshot, refreshPlaybackStatus, useSharedPlaybackStatus } from "../stores/playbackStatusStore";
 import { logLyricsConsole } from "../diagnostics/lyricsConsole";
 import { openAlbumDetailForTrack } from "../utils/albumNavigation";
 import { serializeFontList } from "../preferences/appearancePreferences";
@@ -149,6 +148,7 @@ type LyricsDisplaySettings = Pick<
   | "lyricsFontSizePx"
   | "lyricsFontFamily"
   | "lyricsFontFilePath"
+  | "lyricsTextDirection"
   | "lyricsColor"
   | "lyricsBackgroundMode"
   | "lyricsCustomWallpaperPath"
@@ -202,6 +202,7 @@ const fallbackLyricsDisplaySettings: LyricsDisplaySettings = {
   lyricsFontSizePx: 40,
   lyricsFontFamily: "Microsoft YaHei",
   lyricsFontFilePath: null,
+  lyricsTextDirection: "horizontal",
   lyricsColor: "#314054",
   lyricsBackgroundMode: "theme",
   lyricsCustomWallpaperPath: null,
@@ -987,6 +988,7 @@ const selectLyricsDisplaySettings = (
   lyricsFontSizePx: settings.lyricsFontSizePx,
   lyricsFontFamily: settings.lyricsFontFamily ?? fallbackLyricsDisplaySettings.lyricsFontFamily,
   lyricsFontFilePath: settings.lyricsFontFilePath ?? fallbackLyricsDisplaySettings.lyricsFontFilePath,
+  lyricsTextDirection: settings.lyricsTextDirection ?? fallbackLyricsDisplaySettings.lyricsTextDirection,
   lyricsColor: settings.lyricsColor,
   lyricsBackgroundMode: settings.lyricsBackgroundMode,
   lyricsCustomWallpaperPath: settings.lyricsCustomWallpaperPath,
@@ -1110,6 +1112,7 @@ const lyricsDisplaySettingsKeys = [
   "lyricsFontSizePx",
   "lyricsFontFamily",
   "lyricsFontFilePath",
+  "lyricsTextDirection",
   "lyricsColor",
   "lyricsBackgroundMode",
   "lyricsCustomWallpaperPath",
@@ -4264,6 +4267,7 @@ export const LyricsPage = ({ initialLyrics, usePlayerDrawerHeader = false }: Lyr
       data-smart-readable={smartReadableColors ? "true" : undefined}
       data-album-transition={isAlbumNavigating ? "true" : undefined}
       data-custom-lrc-dragging={isCustomLyricsDragging}
+      data-lyrics-text-direction={lyricsDisplaySettings.lyricsTextDirection}
       data-view-mode={lyricsViewMode}
       data-mv-lyrics-hidden={shouldHideLyricsInMv ? "true" : undefined}
       data-airplay-receiver={isCurrentAirPlayReceiverTrack ? "true" : undefined}
@@ -4404,6 +4408,7 @@ export const LyricsPage = ({ initialLyrics, usePlayerDrawerHeader = false }: Lyr
             positionUpdatedAtMs={seekPreviewSeconds === null ? mvAudioClock.updatedAtMs : performance.now()}
             wordHighlightEnabled={lyricsDisplaySettings.lyricsWordHighlightEnabled !== false && lyricsDisplaySettings.lowLoadPlaybackModeEnabled !== true}
             highFrequencyUpdatesEnabled={lyricsDisplaySettings.lowLoadPlaybackModeEnabled !== true}
+            textDirection={lyricsDisplaySettings.lyricsTextDirection ?? "horizontal"}
             showRomanization={isLyricsDisplaySettingsReady && lyricsDisplaySettings.lyricsRomanizationEnabled}
             preferKanaPronunciation={lyricsDisplaySettings.lyricsUtatenKanaEnabled === true}
             showTranslation={isLyricsDisplaySettingsReady && lyricsDisplaySettings.lyricsTranslationEnabled}

--- a/src/renderer/styles/desktop-lyrics.css
+++ b/src/renderer/styles/desktop-lyrics.css
@@ -79,13 +79,42 @@ html[data-theme-preset="darkSideMoon"] .desktop-lyrics-app[data-color-mode="them
   -webkit-app-region: drag;
 }
 
+.desktop-lyrics-app[data-text-direction="vertical"] .desktop-lyrics-lines {
+  width: auto;
+  max-width: calc(100vw - 36px);
+  max-height: calc(100vh - 20px);
+  align-items: center;
+  justify-content: center;
+}
+
 .desktop-lyrics-app[data-locked="true"] .desktop-lyrics-lines {
   pointer-events: none;
   -webkit-app-region: no-drag;
 }
 
+.desktop-lyrics-line-text {
+  display: grid;
+  width: fit-content;
+  justify-items: center;
+  gap: 3px;
+  -webkit-app-region: inherit;
+}
+
+.desktop-lyrics-app[data-text-direction="vertical"] .desktop-lyrics-line-text {
+  max-height: calc(100vh - 20px);
+  display: inline-flex;
+  width: fit-content;
+  height: calc(100vh - 20px);
+  min-width: 0;
+  flex-direction: row-reverse;
+  align-items: center;
+  justify-content: center;
+  gap: clamp(6px, 1.4vw, 18px);
+  overflow: visible;
+}
+
 .desktop-lyrics-lines strong,
-.desktop-lyrics-lines span {
+.desktop-lyrics-line-text > span {
   display: block;
   max-width: none;
   overflow: visible;
@@ -97,6 +126,152 @@ html[data-theme-preset="darkSideMoon"] .desktop-lyrics-app[data-color-mode="them
     0 0 3px color-mix(in srgb, var(--desktop-lyrics-stroke-color) 72%, transparent),
     0 3px 12px rgb(0 0 0 / 0.28);
   -webkit-font-smoothing: antialiased;
+  -webkit-app-region: inherit;
+}
+
+.desktop-lyrics-app[data-text-direction="vertical"] .desktop-lyrics-lines strong,
+.desktop-lyrics-app[data-text-direction="vertical"] .desktop-lyrics-line-text > span {
+  display: inline-flex;
+  max-height: calc(100vh - 20px);
+  height: calc(100vh - 20px);
+  max-width: none;
+  flex: 0 0 auto;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  line-height: 1;
+  white-space: normal;
+  overflow-wrap: normal;
+  word-break: keep-all;
+  line-break: strict;
+  hyphens: none;
+  text-align: center;
+  writing-mode: horizontal-tb;
+}
+
+.desktop-lyrics-app[data-text-direction="vertical"] .desktop-lyrics-lines strong {
+  width: calc(var(--desktop-lyrics-font-size) * 1.22);
+  font-size: calc(var(--desktop-lyrics-font-size) * var(--desktop-lyrics-text-fit-scale, 1));
+  font-weight: 700;
+  line-height: 1.02;
+}
+
+.desktop-lyrics-app[data-text-direction="vertical"] .desktop-lyrics-line-text > span {
+  width: calc(var(--desktop-lyrics-font-size) * 0.72);
+}
+
+.desktop-lyrics-app[data-text-direction="vertical"] .desktop-lyrics-line-text > span[data-secondary-kind="romanization"] {
+  width: calc(var(--desktop-lyrics-font-size) * 0.84);
+}
+
+.desktop-lyrics-upright-character {
+  display: block;
+  min-width: 1em;
+  min-height: 1em;
+  line-height: 1;
+  text-align: center;
+  white-space: pre;
+  writing-mode: horizontal-tb;
+  -webkit-app-region: inherit;
+}
+
+.desktop-lyrics-upright-character[data-sideways="true"],
+.desktop-lyrics-romanization-character[data-sideways="true"] {
+  min-width: 1em;
+  min-height: auto;
+  line-height: 1;
+  writing-mode: vertical-rl;
+  text-orientation: mixed;
+}
+
+.desktop-lyrics-upright-character[data-sideways="true"] + .desktop-lyrics-upright-character[data-sideways="true"],
+.desktop-lyrics-romanization-character[data-sideways="true"] + .desktop-lyrics-romanization-character[data-sideways="true"] {
+  margin-top: 0.28em;
+}
+
+.desktop-lyrics-romanization-text {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.22em;
+  -webkit-app-region: inherit;
+}
+
+.desktop-lyrics-romanization-token {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: center;
+  line-height: 0.96;
+  -webkit-app-region: inherit;
+}
+
+.desktop-lyrics-romanization-character {
+  display: block;
+  min-width: 1em;
+  min-height: 0.86em;
+  line-height: 0.86;
+  text-align: center;
+  white-space: pre;
+  writing-mode: horizontal-tb;
+  -webkit-app-region: inherit;
+}
+
+.desktop-lyrics-romanization-character[data-sideways="true"] {
+  min-height: auto;
+  line-height: 0.92;
+}
+
+.desktop-lyrics-scroll-clip {
+  position: relative;
+  display: flex;
+  width: 100%;
+  height: 100%;
+  max-height: 100%;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  color: inherit;
+  font: inherit;
+  text-shadow: inherit;
+  -webkit-app-region: inherit;
+}
+
+.desktop-lyrics-scroll-clip[data-overflow="true"] {
+  -webkit-mask-image: linear-gradient(
+    to bottom,
+    transparent,
+    #000 7%,
+    #000 93%,
+    transparent
+  );
+  mask-image: linear-gradient(
+    to bottom,
+    transparent,
+    #000 7%,
+    #000 93%,
+    transparent
+  );
+}
+
+.desktop-lyrics-scroll-track {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  color: inherit;
+  font: inherit;
+  text-shadow: inherit;
+  transform: translateY(var(--desktop-lyrics-scroll-offset, 0px));
+  will-change: transform;
+  -webkit-app-region: inherit;
+}
+
+.desktop-lyrics-scroll-clip[data-overflow="true"] {
+  align-items: flex-start;
+}
+
+.desktop-lyrics-scroll-clip[data-overflow="true"] .desktop-lyrics-scroll-track {
+  justify-content: flex-start;
 }
 
 .desktop-lyrics-lines strong {
@@ -114,11 +289,25 @@ html[data-theme-preset="darkSideMoon"] .desktop-lyrics-app[data-color-mode="them
   -webkit-text-fill-color: transparent;
 }
 
-.desktop-lyrics-lines span {
+.desktop-lyrics-app[data-text-direction="vertical"][data-color-mode="theme"] .desktop-lyrics-lines strong {
+  color: var(--desktop-lyrics-theme-color);
+  background-image: none;
+  background-clip: border-box;
+  text-shadow: var(--desktop-lyrics-theme-shadow);
+  -webkit-background-clip: border-box;
+  -webkit-text-fill-color: currentColor;
+}
+
+.desktop-lyrics-line-text > span {
   color: color-mix(in srgb, var(--desktop-lyrics-color) 82%, transparent);
   font-size: calc(var(--desktop-lyrics-font-size) * 0.56);
   font-weight: 600;
   line-height: 1.2;
+}
+
+.desktop-lyrics-app[data-text-direction="vertical"] .desktop-lyrics-line-text > span {
+  font-size: calc(var(--desktop-lyrics-font-size) * 0.56);
+  line-height: 1.16;
 }
 
 .desktop-lyrics-menu {

--- a/src/renderer/styles/lyrics.css
+++ b/src/renderer/styles/lyrics.css
@@ -606,14 +606,14 @@ html:not([data-theme="dark"]) .lyrics-page[data-background="customWallpaper"]:ha
   opacity: 0.58;
 }
 
-.lyrics-page:has(.lyrics-mv-panel[data-lyrics-readability="true"]) .lyrics-line span {
+.lyrics-page:has(.lyrics-mv-panel[data-lyrics-readability="true"]) .lyrics-line .lyrics-line-primary {
   text-shadow:
     0 1px 2px rgba(0, 0, 0, 0.72),
     0 4px 12px rgba(0, 0, 0, 0.46),
     0 0 24px rgba(0, 0, 0, 0.22);
 }
 
-.lyrics-page:has(.lyrics-mv-panel[data-lyrics-readability="true"]) .lyrics-line[data-active="true"] span {
+.lyrics-page:has(.lyrics-mv-panel[data-lyrics-readability="true"]) .lyrics-line[data-active="true"] .lyrics-line-primary {
   text-shadow:
     0 1px 2px rgba(0, 0, 0, 0.78),
     0 5px 14px rgba(0, 0, 0, 0.52),
@@ -1850,6 +1850,12 @@ html[data-theme="dark"] .mv-offset-buttons button:hover {
   gap: calc(clamp(22px, 3.2vh, 42px) * var(--lyrics-line-spacing, 0.82));
 }
 
+.lyrics-scroll[data-text-direction="vertical"] {
+  width: min(100%, 1120px);
+  align-items: center;
+  gap: calc(clamp(26px, 4.8vh, 62px) * var(--lyrics-line-spacing, 0.82));
+}
+
 .lyrics-line {
   --lyrics-line-y: 18px;
   --lyrics-line-scale: 0.975;
@@ -1876,6 +1882,11 @@ html[data-theme="dark"] .mv-offset-buttons button:hover {
     text-shadow 640ms ease,
     transform 860ms cubic-bezier(0.25, 0.1, 0.25, 1);
   will-change: opacity, transform;
+}
+
+.lyrics-scroll[data-text-direction="vertical"] .lyrics-line {
+  min-height: auto;
+  padding: clamp(8px, 1.2vh, 16px) clamp(10px, 1.4vw, 22px);
 }
 
 .lyrics-line:hover {
@@ -1945,7 +1956,7 @@ html[data-theme="dark"] .mv-offset-buttons button:hover {
   opacity: 1;
 }
 
-.lyrics-page[data-lyrics-color-mode="theme"]:not([data-smart-readable="true"]) .lyrics-line[data-active="true"] span {
+.lyrics-page[data-lyrics-color-mode="theme"]:not([data-smart-readable="true"]) .lyrics-line[data-active="true"] .lyrics-line-primary {
   color: var(--echo-lyrics-gradient-start);
   background-image: var(--lyrics-active-gradient);
   background-size: 100% 100%;
@@ -1994,7 +2005,28 @@ html[data-theme="dark"] .lyrics-page[data-background="theme"] .lyrics-line[data-
   min-height: calc(clamp(96px, 11vh, 144px) * var(--lyrics-line-spacing, 0.82));
 }
 
-.lyrics-line span {
+.lyrics-line-text {
+  display: grid;
+  max-width: min(100%, var(--lyrics-line-max-width));
+  min-width: 0;
+  justify-items: center;
+  gap: inherit;
+}
+
+.lyrics-scroll[data-text-direction="vertical"] .lyrics-line-text {
+  display: inline-flex;
+  width: fit-content;
+  min-width: 0;
+  max-width: none;
+  max-height: none;
+  flex-direction: row-reverse;
+  align-items: flex-start;
+  justify-content: center;
+  column-gap: clamp(8px, 1.4vw, 22px);
+  overflow: visible;
+}
+
+.lyrics-line-primary {
   display: inline-block;
   max-width: min(100%, var(--lyrics-line-max-width));
   min-width: 0;
@@ -2013,6 +2045,72 @@ html[data-theme="dark"] .lyrics-page[data-background="theme"] .lyrics-line[data-
     text-shadow 320ms ease;
   transform-origin: center;
   will-change: opacity;
+}
+
+.lyrics-scroll[data-text-direction="vertical"] .lyrics-line-primary {
+  display: inline-flex;
+  width: fit-content;
+  max-height: none;
+  max-width: none;
+  flex: 0 0 auto;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  overflow-wrap: normal;
+  word-break: keep-all;
+  line-break: strict;
+  white-space: normal;
+  hyphens: none;
+  line-height: 1;
+  text-align: center;
+  writing-mode: horizontal-tb;
+}
+
+.lyrics-scroll[data-text-direction="vertical"] .lyrics-word {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: center;
+  margin: 0;
+  padding: 0;
+}
+
+.lyrics-upright-character {
+  display: block;
+  min-width: 1em;
+  min-height: 0.96em;
+  line-height: 0.96;
+  text-align: center;
+  white-space: pre;
+  writing-mode: horizontal-tb;
+}
+
+.lyrics-upright-character[data-sideways="true"] {
+  min-width: 1em;
+  min-height: auto;
+  line-height: 1;
+  writing-mode: vertical-rl;
+  text-orientation: mixed;
+}
+
+.lyrics-upright-character[data-sideways="true"] + .lyrics-upright-character[data-sideways="true"] {
+  margin-top: 0.28em;
+}
+
+.lyrics-page[data-lyrics-color-mode="theme"]:not([data-smart-readable="true"]) .lyrics-scroll[data-text-direction="vertical"] .lyrics-line[data-active="true"] .lyrics-line-primary .lyrics-upright-character {
+  color: var(--echo-lyrics-gradient-start);
+  background-image: none;
+  background-size: auto;
+  background-clip: border-box;
+  text-shadow: var(--lyrics-active-shadow);
+  -webkit-background-clip: border-box;
+  -webkit-text-fill-color: currentColor;
+}
+
+.lyrics-scroll[data-text-direction="vertical"] .lyrics-line[data-active="true"][data-word-highlight="true"] .lyrics-word .lyrics-upright-character {
+  background-image: inherit;
+  background-clip: text;
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
 }
 
 .lyrics-word {
@@ -2052,6 +2150,15 @@ html[data-theme="dark"] .lyrics-page[data-background="theme"] .lyrics-line[data-
   opacity: 0.84;
 }
 
+.lyrics-scroll[data-text-direction="vertical"] .lyrics-line[data-active="true"][data-word-highlight="true"] .lyrics-word {
+  background-image: linear-gradient(
+    180deg,
+    var(--lyrics-word-fill-color) 0 calc((var(--lyrics-word-progress) * 100%) - 0.12em),
+    color-mix(in srgb, var(--lyrics-word-fill-color) 72%, var(--lyrics-word-upcoming-color) 28%) calc(var(--lyrics-word-progress) * 100%),
+    var(--lyrics-word-upcoming-color) calc((var(--lyrics-word-progress) * 100%) + 0.12em) 100%
+  );
+}
+
 .lyrics-line[data-active="true"][data-word-highlight="true"] .lyrics-word[data-word-state="current"] {
   --lyrics-word-upcoming-color: color-mix(in srgb, var(--lyrics-readable-color) var(--lyrics-current-word-clarity, 70%), transparent);
   filter:
@@ -2065,16 +2172,16 @@ html[data-theme="dark"] .lyrics-page[data-background="theme"] .lyrics-line[data-
   opacity: 1;
 }
 
-.lyrics-line[data-active="true"] span {
+.lyrics-line[data-active="true"] .lyrics-line-primary {
   font-size: calc(var(--lyrics-font-size) * 1.25);
   line-height: 1.18;
 }
 
-.lyrics-line[data-density="medium"] span {
+.lyrics-line[data-density="medium"] .lyrics-line-primary {
   font-size: calc(var(--lyrics-font-size) * 0.84);
 }
 
-.lyrics-line[data-density="medium"][data-active="true"] span {
+.lyrics-line[data-density="medium"][data-active="true"] .lyrics-line-primary {
   font-size: calc(var(--lyrics-font-size) * 1.12);
 }
 
@@ -2088,44 +2195,66 @@ html[data-theme="dark"] .lyrics-page[data-background="theme"] .lyrics-line[data-
   min-height: calc(clamp(102px, 11.6vh, 150px) * var(--lyrics-line-spacing, 0.82));
 }
 
-.lyrics-line[data-density="long"] span {
+.lyrics-line[data-density="long"] .lyrics-line-primary {
   font-size: calc(var(--lyrics-font-size) * 0.74);
   line-height: 1.24;
 }
 
-.lyrics-line[data-density="long"][data-active="true"] span {
+.lyrics-line[data-density="long"][data-active="true"] .lyrics-line-primary {
   font-size: calc(var(--lyrics-font-size) * 0.96);
   line-height: 1.22;
 }
 
-.lyrics-line[data-density="dense"] span {
+.lyrics-line[data-density="dense"] .lyrics-line-primary {
   font-size: calc(var(--lyrics-font-size) * 0.64);
   line-height: 1.28;
 }
 
-.lyrics-line[data-density="dense"][data-active="true"] span {
+.lyrics-line[data-density="dense"][data-active="true"] .lyrics-line-primary {
   font-size: calc(var(--lyrics-font-size) * 0.84);
   line-height: 1.26;
 }
 
-.lyrics-line[data-secondary-lines="2"][data-active="true"] span {
+.lyrics-line[data-secondary-lines="2"][data-active="true"] .lyrics-line-primary {
   font-size: calc(var(--lyrics-font-size) * 1.06);
   line-height: 1.16;
 }
 
-.lyrics-line[data-secondary-lines="2"][data-density="medium"][data-active="true"] span {
+.lyrics-line[data-secondary-lines="2"][data-density="medium"][data-active="true"] .lyrics-line-primary {
   font-size: calc(var(--lyrics-font-size) * 1);
   line-height: 1.18;
 }
 
-.lyrics-line[data-secondary-lines="2"][data-density="long"][data-active="true"] span {
+.lyrics-line[data-secondary-lines="2"][data-density="long"][data-active="true"] .lyrics-line-primary {
   font-size: calc(var(--lyrics-font-size) * 0.9);
   line-height: 1.22;
 }
 
-.lyrics-line[data-secondary-lines="2"][data-density="dense"][data-active="true"] span {
+.lyrics-line[data-secondary-lines="2"][data-density="dense"][data-active="true"] .lyrics-line-primary {
   font-size: calc(var(--lyrics-font-size) * 0.78);
   line-height: 1.26;
+}
+
+.lyrics-scroll[data-text-direction="vertical"] .lyrics-line,
+.lyrics-scroll[data-text-direction="vertical"] .lyrics-line[data-secondary-lines="1"],
+.lyrics-scroll[data-text-direction="vertical"] .lyrics-line[data-secondary-lines="2"],
+.lyrics-scroll[data-text-direction="vertical"] .lyrics-line[data-secondary-lines="2"][data-active="true"],
+.lyrics-scroll[data-text-direction="vertical"] .lyrics-line[data-density="long"],
+.lyrics-scroll[data-text-direction="vertical"] .lyrics-line[data-density="dense"] {
+  min-height: auto;
+}
+
+.lyrics-scroll[data-text-direction="vertical"] .lyrics-line[data-active="true"] .lyrics-line-primary,
+.lyrics-scroll[data-text-direction="vertical"] .lyrics-line[data-density="medium"][data-active="true"] .lyrics-line-primary,
+.lyrics-scroll[data-text-direction="vertical"] .lyrics-line[data-density="long"][data-active="true"] .lyrics-line-primary,
+.lyrics-scroll[data-text-direction="vertical"] .lyrics-line[data-density="dense"][data-active="true"] .lyrics-line-primary,
+.lyrics-scroll[data-text-direction="vertical"] .lyrics-line[data-secondary-lines="2"][data-active="true"] .lyrics-line-primary,
+.lyrics-scroll[data-text-direction="vertical"] .lyrics-line[data-secondary-lines="2"][data-density="medium"][data-active="true"] .lyrics-line-primary,
+.lyrics-scroll[data-text-direction="vertical"] .lyrics-line[data-secondary-lines="2"][data-density="long"][data-active="true"] .lyrics-line-primary,
+.lyrics-scroll[data-text-direction="vertical"] .lyrics-line[data-secondary-lines="2"][data-density="dense"][data-active="true"] .lyrics-line-primary {
+  font-size: calc(var(--lyrics-font-size) * 1.25);
+  font-weight: 850;
+  line-height: 1;
 }
 
 .lyrics-line em,
@@ -2140,6 +2269,26 @@ html[data-theme="dark"] .lyrics-page[data-background="theme"] .lyrics-line[data-
     opacity 320ms ease;
   transform-origin: center;
   will-change: opacity;
+}
+
+.lyrics-scroll[data-text-direction="vertical"] .lyrics-line small,
+.lyrics-scroll[data-text-direction="vertical"] .lyrics-line em {
+  display: inline-flex;
+  width: fit-content;
+  max-height: none;
+  max-width: none;
+  flex: 0 0 auto;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  overflow-wrap: normal;
+  word-break: keep-all;
+  line-break: strict;
+  white-space: normal;
+  hyphens: none;
+  line-height: 1;
+  text-align: center;
+  writing-mode: horizontal-tb;
 }
 
 .lyrics-line small {
@@ -2188,41 +2337,41 @@ html[data-theme="dark"] .lyrics-page[data-background="theme"] .lyrics-line[data-
   min-height: calc(clamp(82px, 9.8vh, 118px) * var(--lyrics-line-spacing, 0.82));
 }
 
-.lyrics-page:has(.lyrics-mv-background) .lyrics-line span {
+.lyrics-page:has(.lyrics-mv-background) .lyrics-line .lyrics-line-primary {
   max-width: min(100%, 1120px, var(--lyrics-line-max-width));
   font-size: calc(var(--lyrics-font-size) * 0.9);
 }
 
-.lyrics-page:has(.lyrics-mv-background) .lyrics-line[data-active="true"] span {
+.lyrics-page:has(.lyrics-mv-background) .lyrics-line[data-active="true"] .lyrics-line-primary {
   font-size: calc(var(--lyrics-font-size) * 1.25);
   line-height: 1.18;
 }
 
-.lyrics-page:has(.lyrics-mv-background) .lyrics-line[data-density="medium"] span {
+.lyrics-page:has(.lyrics-mv-background) .lyrics-line[data-density="medium"] .lyrics-line-primary {
   font-size: calc(var(--lyrics-font-size) * 0.84);
 }
 
-.lyrics-page:has(.lyrics-mv-background) .lyrics-line[data-density="medium"][data-active="true"] span {
+.lyrics-page:has(.lyrics-mv-background) .lyrics-line[data-density="medium"][data-active="true"] .lyrics-line-primary {
   font-size: calc(var(--lyrics-font-size) * 1.12);
 }
 
-.lyrics-page:has(.lyrics-mv-background) .lyrics-line[data-density="long"] span {
+.lyrics-page:has(.lyrics-mv-background) .lyrics-line[data-density="long"] .lyrics-line-primary {
   font-size: calc(var(--lyrics-font-size) * 0.74);
 }
 
-.lyrics-page:has(.lyrics-mv-background) .lyrics-line[data-density="long"][data-active="true"] span {
+.lyrics-page:has(.lyrics-mv-background) .lyrics-line[data-density="long"][data-active="true"] .lyrics-line-primary {
   font-size: calc(var(--lyrics-font-size) * 0.96);
 }
 
-.lyrics-page:has(.lyrics-mv-background) .lyrics-line[data-density="dense"] span {
+.lyrics-page:has(.lyrics-mv-background) .lyrics-line[data-density="dense"] .lyrics-line-primary {
   font-size: calc(var(--lyrics-font-size) * 0.64);
 }
 
-.lyrics-page:has(.lyrics-mv-background) .lyrics-line[data-density="dense"][data-active="true"] span {
+.lyrics-page:has(.lyrics-mv-background) .lyrics-line[data-density="dense"][data-active="true"] .lyrics-line-primary {
   font-size: calc(var(--lyrics-font-size) * 0.84);
 }
 
-.lyrics-page:has(.lyrics-mv-background) .lyrics-line[data-secondary-lines="2"][data-active="true"] span {
+.lyrics-page:has(.lyrics-mv-background) .lyrics-line[data-secondary-lines="2"][data-active="true"] .lyrics-line-primary {
   font-size: calc(var(--lyrics-font-size) * 1.06);
 }
 
@@ -2982,7 +3131,7 @@ html:not([data-theme="dark"]) .lyrics-page:has(.lyrics-mv-panel[data-mv-enabled=
   min-height: calc(clamp(82px, 9.6vh, 122px) * var(--lyrics-line-spacing, 0.82));
 }
 
-.lyrics-page:has(.lyrics-mv-panel[data-mv-enabled="false"]) .lyrics-line span {
+.lyrics-page:has(.lyrics-mv-panel[data-mv-enabled="false"]) .lyrics-line .lyrics-line-primary {
   max-width: min(100%, 1080px, var(--lyrics-line-max-width));
 }
 
@@ -4465,7 +4614,7 @@ html[data-theme="dark"] .lyrics-copy-notice {
   text-shadow: var(--lyrics-smart-shadow);
 }
 
-.lyrics-page[data-smart-readable="true"] .lyrics-line span {
+.lyrics-page[data-smart-readable="true"] .lyrics-line .lyrics-line-primary {
   -webkit-text-stroke: var(--lyrics-smart-stroke);
   background: var(--lyrics-smart-scrim-background);
   border-radius: 0.14em;
@@ -4486,7 +4635,7 @@ html[data-theme="dark"] .lyrics-copy-notice {
   text-shadow: var(--lyrics-smart-shadow);
 }
 
-.lyrics-page:has(.lyrics-mv-panel[data-lyrics-readability="true"]) .lyrics-line span {
+.lyrics-page:has(.lyrics-mv-panel[data-lyrics-readability="true"]) .lyrics-line .lyrics-line-primary {
   -webkit-text-stroke: 0.012em rgba(0, 0, 0, 0.48);
   background: transparent;
   border-radius: 0;
@@ -4498,7 +4647,7 @@ html[data-theme="dark"] .lyrics-copy-notice {
     0 0 28px rgba(0, 0, 0, 0.3);
 }
 
-.lyrics-page:has(.lyrics-mv-panel[data-lyrics-readability="true"]) .lyrics-line[data-active="true"] span {
+.lyrics-page:has(.lyrics-mv-panel[data-lyrics-readability="true"]) .lyrics-line[data-active="true"] .lyrics-line-primary {
   -webkit-text-stroke: 0.014em rgba(0, 0, 0, 0.56);
   text-shadow:
     0 1px 2px rgba(0, 0, 0, 0.84),
@@ -4592,7 +4741,7 @@ html[data-theme="dark"] .lyrics-copy-notice {
     font-size: 16px;
   }
 
-  .lyrics-line span {
+  .lyrics-line .lyrics-line-primary {
     font-size: calc(var(--lyrics-font-size) * 0.82);
   }
 
@@ -4766,7 +4915,7 @@ html[data-theme="dark"] .lyrics-copy-notice {
     font-size: 16px;
   }
 
-  .lyrics-line span {
+  .lyrics-line .lyrics-line-primary {
     font-size: calc(var(--lyrics-font-size) * 0.78);
   }
 
@@ -4987,7 +5136,7 @@ html[data-theme="dark"] .lyrics-copy-notice {
     min-height: calc(clamp(68px, 8vh, 96px) * var(--lyrics-line-spacing, 0.82));
   }
 
-  .app-shell--lyrics-player-drawer .lyrics-page:has(.lyrics-mv-panel[data-mv-enabled="false"]) .lyrics-line span {
+  .app-shell--lyrics-player-drawer .lyrics-page:has(.lyrics-mv-panel[data-mv-enabled="false"]) .lyrics-line .lyrics-line-primary {
     overflow-wrap: normal;
     word-break: normal;
     hyphens: none;
@@ -4995,7 +5144,7 @@ html[data-theme="dark"] .lyrics-copy-notice {
     line-height: 1.18;
   }
 
-  .app-shell--lyrics-player-drawer .lyrics-page:has(.lyrics-mv-panel[data-mv-enabled="false"]) .lyrics-line[data-active="true"] span {
+  .app-shell--lyrics-player-drawer .lyrics-page:has(.lyrics-mv-panel[data-mv-enabled="false"]) .lyrics-line[data-active="true"] .lyrics-line-primary {
     font-size: min(calc(var(--lyrics-font-size) * 0.92), 34px);
     line-height: 1.2;
   }
@@ -5172,7 +5321,7 @@ html[data-theme="dark"] .lyrics-copy-notice {
   .lyrics-page[data-album-transition="true"] .lyrics-left-panel,
   .lyrics-page[data-album-transition="true"] .lyrics-backdrop::after,
   .lyrics-line,
-  .lyrics-line span,
+  .lyrics-line .lyrics-line-primary,
   .lyrics-word,
   .lyrics-line small,
   .lyrics-line em,

--- a/src/shared/types/appSettings.ts
+++ b/src/shared/types/appSettings.ts
@@ -10,6 +10,7 @@ import type { SidebarRouteId } from './sidebar';
 export type ScanPerformanceMode = 'low' | 'balanced' | 'performance';
 export type RemoteCoverLoadPerformanceMode = 'low' | 'balanced' | 'aggressive' | 'lan';
 export type LyricsBackgroundMode = 'theme' | 'cover' | 'coverColor' | 'customWallpaper';
+export type LyricsTextDirection = 'horizontal' | 'vertical';
 export type LyricsMiniPlayerColorMode = 'default' | 'custom' | 'cover';
 export type DesktopLyricsColorMode = 'theme' | 'custom';
 export type AppWallpaperMediaType = 'image' | 'video';
@@ -305,6 +306,7 @@ export type AppSettings = {
   lyricsSecondaryFontSizePx?: number;
   lyricsFontFamily?: string;
   lyricsFontFilePath?: string | null;
+  lyricsTextDirection?: LyricsTextDirection;
   lyricsLineSpacingPercent?: number;
   lyricsLineMaxChars?: number;
   lyricsContextOpacityPercent?: number;
@@ -327,6 +329,7 @@ export type AppSettings = {
   desktopLyricsColor?: string;
   desktopLyricsStrokeColor?: string;
   desktopLyricsOpacityPercent?: number;
+  desktopLyricsTextDirection?: LyricsTextDirection;
   desktopLyricsRomanizationEnabled?: boolean;
   desktopLyricsTranslationEnabled?: boolean;
   desktopLyricsBounds?: DesktopLyricsBounds | null;

--- a/src/shared/types/desktopLyrics.ts
+++ b/src/shared/types/desktopLyrics.ts
@@ -12,6 +12,7 @@ export type DesktopLyricsStylePatch = Partial<Pick<
   | 'desktopLyricsColor'
   | 'desktopLyricsStrokeColor'
   | 'desktopLyricsOpacityPercent'
+  | 'desktopLyricsTextDirection'
   | 'desktopLyricsRomanizationEnabled'
   | 'desktopLyricsTranslationEnabled'
 >>;
@@ -32,6 +33,7 @@ export type DesktopLyricsState = {
     | 'desktopLyricsColor'
     | 'desktopLyricsStrokeColor'
     | 'desktopLyricsOpacityPercent'
+    | 'desktopLyricsTextDirection'
     | 'desktopLyricsRomanizationEnabled'
     | 'desktopLyricsTranslationEnabled'
     | 'desktopLyricsBounds'


### PR DESCRIPTION
## 概述
本人经常用竖排歌词,看了眼播放器竟然没有（）那就补个,顺便补个播放按钮

为主歌词页和桌面歌词新增滚动竖排歌词显示能力，并在桌面歌词浮动工具条中补充播放 / 暂停按钮与横竖排切换按钮。

默认仍保持横排显示，只有用户显式切换后才启用竖排，因此不会改变现有歌词页、桌面歌词、MV 或播放控制的默认行为。

## 主要改动

- 新增歌词文字方向设置：
  - `lyricsTextDirection`
  - `desktopLyricsTextDirection`
- 主歌词页支持横排 / 竖排切换。
- 桌面歌词支持横排 / 竖排切换。
- 桌面歌词浮动 UI 新增播放 / 暂停按钮。
- 桌面歌词浮动 UI 新增横排 / 竖排快捷切换按钮。
- 竖排模式下保留原文、罗马音、翻译的分组显示。
- 竖排长歌词按歌词进度滚动，避免字体被强制缩小或显示不全。
- 英文、数字和罗马音在竖排中按 token 侧排，避免逐字母竖排导致空间占用过大。
- 默认值保持横排，非法设置值会归一化为默认值。
<img width="678" height="650" alt="PixPin_2026-06-05_02-57-48" src="https://github.com/user-attachments/assets/d9384b26-5f13-4f9e-a098-64e1bbde5c80" />
<img width="366" height="333" alt="PixPin_2026-06-05_02-58-27" src="https://github.com/user-attachments/assets/d6d9ba2a-6be0-475b-b7d8-c6605d5f0ae0" />

## 兼容性

默认配置仍为：

```ts
lyricsTextDirection: 'horizontal'
desktopLyricsTextDirection: 'horizontal'
```

因此用户不主动切换时，现有横排歌词显示不受影响。

未改动播放队列、音频输出设备、MV 播放、歌词时间轴或点击 seek 逻辑。桌面歌词播放 / 暂停按钮只调用现有 `play()` / `pause()`，不会额外 seek，也不会强制启用渐入渐出。

## 文件改动

共修改 19 个源码 / 测试文件：

| 文件 | 改动说明 |
| --- | --- |
| `src/shared/types/appSettings.ts` | 新增歌词文字方向类型与主歌词 / 桌面歌词方向设置字段 |
| `src/shared/types/desktopLyrics.ts` | 桌面歌词样式 patch 支持文字方向 |
| `src/main/app/appSettings.ts` | 增加默认值与非法值归一化 |
| `src/main/app/appSettings.test.ts` | 补充歌词方向默认值、合法值、非法值归一化测试 |
| `src/main/ipc/desktopLyricsIpc.ts` | 桌面歌词样式 IPC 支持 `desktopLyricsTextDirection` |
| `src/main/app/desktopLyricsWindow.ts` | 桌面歌词窗口状态同步与竖排尺寸处理 |
| `src/main/app/desktopLyricsWindow.test.ts` | 补充桌面歌词窗口方向相关测试 |
| `src/renderer/components/lyrics/VerticalText.tsx` | 新增竖排文本 token 渲染组件 |
| `src/renderer/components/lyrics/LyricsLine.tsx` | 主歌词行支持竖排原文、罗马音、翻译渲染 |
| `src/renderer/components/lyrics/LyricsView.tsx` | 透传歌词文字方向到歌词行 |
| `src/renderer/pages/LyricsPage.tsx` | 读取并应用主歌词页文字方向设置 |
| `src/renderer/pages/LyricsPage.test.tsx` | 补充主歌词竖排、横排默认、点击不 seek 等测试 |
| `src/renderer/components/lyrics/LyricsSettingsDrawer.tsx` | 设置面板新增主歌词 / 桌面歌词文字方向选项 |
| `src/renderer/components/lyrics/LyricsSettingsDrawer.test.tsx` | 补充设置面板方向切换测试 |
| `src/renderer/desktop-lyrics/DesktopLyricsApp.tsx` | 桌面歌词竖排、长句滚动、浮动 UI 播放/暂停与横竖切换 |
| `src/renderer/desktop-lyrics/DesktopLyricsApp.test.tsx` | 补充桌面歌词竖排、播放/暂停、hover、锁定穿透等回归测试 |
| `src/renderer/styles/lyrics.css` | 主歌词竖排布局、字号、间距、颜色与逐字高亮样式 |
| `src/renderer/styles/desktop-lyrics.css` | 桌面歌词竖排布局、滚动、hover 命中区与颜色样式 |
| `src/renderer/i18n/locales.ts` | 补齐简中、繁中、英文、日文文案 |

## 测试

已执行：

```bash
npx vitest run src/main/app/appSettings.test.ts src/renderer/pages/LyricsPage.test.tsx src/renderer/components/lyrics/LyricsSettingsDrawer.test.tsx src/renderer/desktop-lyrics/DesktopLyricsApp.test.tsx
```

结果：

```text
Test Files  4 passed
Tests       259 passed
```

已执行：

```bash
npm run typecheck
```

结果：

```text
通过
```

针对本次修改的 TS / TSX 文件执行 ESLint：

```bash
npx eslint <本次修改的 TS/TSX 文件>
```

结果：

```text
0 error
3 warning
```

剩余 warning 为 hook dependency 相关提示，未阻断测试、类型检查或构筑。

## 构筑验证

完整执行：

```bash
npm run build
node scripts/build-win-unsigned.mjs
npm run verify:airplay-package
npm run ensure:native:electron
```

结果均通过，并生成：

```text
dist/win-unpacked/ECHO NEXT.exe
dist/ECHO-NEXT-Setup-26.6.4.exe
dist/ECHO-NEXT-Portable-26.6.4.exe
```
