### PR TITLE
feat: 加了个睡眠定时器功能

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,9 @@ dist-packaged*/
 
 # Local runtime state
 /room-correction-state.json
+
+# Local config files (not for upstream)
+CLAUDE.md
+FORK.md
+docs/agents/
+prd-sleep-timer.md

--- a/src/main/app/lifecycle.ts
+++ b/src/main/app/lifecycle.ts
@@ -34,6 +34,7 @@ import { closeDefaultMvService } from '../mv/MvService';
 import { closeDefaultStreamingService } from '../streaming/StreamingService';
 import { disposeDefaultAudioSessionGracefully } from '../audio/AudioSession';
 import { closeDefaultLibraryDatabaseManager, getLibraryDatabaseManager } from '../database/LibraryDatabaseManager';
+import { getSleepTimerService } from '../sleepTimer/SleepTimerService';
 import { isLibraryRecoveryMode } from './libraryRecoveryMode';
 import { applyNetworkProxySettings } from '../network/proxySettings';
 import { markStartupStage, openSafeModeStartupConsoleIfEnabled } from '../diagnostics/StartupDiagnostics';
@@ -348,6 +349,7 @@ export const registerAppLifecycle = (): void => {
     await disposeConnectService();
     await disposeSmtcIntegration();
     await disposeDefaultAudioSessionGracefully('app-quit');
+    getSleepTimerService().dispose();
     disposeDataBackupScheduler();
     disposeBackgroundPlaybackShortcuts();
     closeDefaultLyricsService();

--- a/src/main/app/tray.ts
+++ b/src/main/app/tray.ts
@@ -4,6 +4,7 @@ import { app, Menu, nativeImage, Tray } from 'electron';
 import { IpcChannels } from '../../shared/constants/ipcChannels';
 import type { GlobalShortcutAction } from '../../shared/types/globalShortcuts';
 import { getMainWindow } from './windowManager';
+import { getSleepTimerService } from '../sleepTimer/SleepTimerService';
 
 const mainOutputDir = import.meta.dirname;
 const appIconPath = join(mainOutputDir, '../../software.ico');
@@ -89,8 +90,40 @@ const createTrayIcon = (): Electron.NativeImage => {
   return nativeImage.createFromDataURL(`data:image/svg+xml;charset=utf-8,${svg}`);
 };
 
-const buildTrayMenu = (): Electron.Menu =>
-  Menu.buildFromTemplate([
+/** 格式化毫秒为 MM:SS */
+const formatRemainingTime = (ms: number): string => {
+  const totalSeconds = Math.ceil(ms / 1000);
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return `${minutes.toString().padStart(2, '0')}:${seconds.toString().padStart(2, '0')}`;
+};
+
+const buildTrayMenu = (): Electron.Menu => {
+  const timerService = getSleepTimerService();
+  const timerStatus = timerService.getStatus();
+
+  // 构建睡眠定时器菜单项
+  const sleepTimerItems: Electron.MenuItemConstructorOptions[] = [];
+  if (timerStatus.isActive) {
+    sleepTimerItems.push({
+      label: `睡眠定时器: 剩余 ${formatRemainingTime(timerStatus.remainingMs)}`,
+      enabled: false,
+    });
+    sleepTimerItems.push({
+      label: '取消定时器',
+      click: () => {
+        timerService.cancel();
+        refreshTrayMenu();
+      },
+    });
+  } else {
+    sleepTimerItems.push({
+      label: '睡眠定时器: 未启动',
+      enabled: false,
+    });
+  }
+
+  return Menu.buildFromTemplate([
     { label: '显示主界面', click: showMainWindow },
     { label: '隐藏主界面', click: hideMainWindow },
     { type: 'separator' },
@@ -103,8 +136,21 @@ const buildTrayMenu = (): Electron.Menu =>
     { label: '隐藏迷你播放器', click: hideMiniPlayer },
     { label: '音频设置', click: openAudioSettings },
     { type: 'separator' },
+    ...sleepTimerItems,
+    { type: 'separator' },
     { label: '退出 ECHO', click: quitApp },
   ]);
+};
+
+/** 刷新托盘菜单（状态变更时调用） */
+const refreshTrayMenu = (): void => {
+  if (tray && !tray.isDestroyed()) {
+    tray.setContextMenu(buildTrayMenu());
+  }
+};
+
+/** SleepTimerService 状态变更回调的取消函数 */
+let timerUnsubscribe: (() => void) | null = null;
 
 export const ensureTray = (): void => {
   if (tray) {
@@ -116,9 +162,17 @@ export const ensureTray = (): void => {
   tray.setToolTip('ECHO NEXT');
   tray.setContextMenu(buildTrayMenu());
   tray.on('click', showMainWindow);
+
+  // 注册睡眠定时器状态变更回调，自动刷新托盘菜单
+  const timerService = getSleepTimerService();
+  timerUnsubscribe = timerService.onChange(() => {
+    refreshTrayMenu();
+  });
 };
 
 export const destroyTray = (): void => {
+  timerUnsubscribe?.();
+  timerUnsubscribe = null;
   tray?.destroy();
   tray = null;
 };

--- a/src/main/ipc/registerIpc.ts
+++ b/src/main/ipc/registerIpc.ts
@@ -61,6 +61,7 @@ import { registerPluginIpc } from './pluginIpc';
 import { registerRemoteSourcesIpc } from './remoteSourcesIpc';
 import { registerSmtcIpc } from './smtcIpc';
 import { registerStreamingIpc } from './streamingIpc';
+import { registerSleepTimerIpc } from './sleepTimerIpc';
 
 const fontMimeTypes: Record<string, string> = {
   '.otf': 'font/otf',
@@ -656,4 +657,5 @@ export const registerIpc = (): void => {
   registerIpcStartupStep('streaming', registerStreamingIpc);
   registerIpcStartupStep('playback', registerPlaybackIpc);
   registerIpcStartupStep('audio', registerAudioIpc);
+  registerIpcStartupStep('sleepTimer', registerSleepTimerIpc);
 };

--- a/src/main/ipc/sleepTimerIpc.ts
+++ b/src/main/ipc/sleepTimerIpc.ts
@@ -1,0 +1,35 @@
+import { ipcMain, BrowserWindow } from 'electron';
+import { IpcChannels } from '../../shared/constants/ipcChannels';
+import { getSleepTimerService } from '../sleepTimer/SleepTimerService';
+import type { SleepTimerStartRequest, SleepTimerStatus } from '../../shared/types/sleepTimer';
+
+/** 注册睡眠定时器相关 IPC 通道 */
+export const registerSleepTimerIpc = (): void => {
+  const service = getSleepTimerService();
+
+  // 启动定时器
+  ipcMain.handle(IpcChannels.SleepTimerStart, async (_event, request: SleepTimerStartRequest): Promise<SleepTimerStatus> => {
+    service.start(request);
+    return service.getStatus();
+  });
+
+  // 取消定时器
+  ipcMain.handle(IpcChannels.SleepTimerCancel, async (): Promise<SleepTimerStatus> => {
+    service.cancel();
+    return service.getStatus();
+  });
+
+  // 查询状态
+  ipcMain.handle(IpcChannels.SleepTimerGetStatus, async (): Promise<SleepTimerStatus> => {
+    return service.getStatus();
+  });
+
+  // 每秒推送剩余时间到所有渲染进程
+  service.onTick((remainingMs) => {
+    for (const win of BrowserWindow.getAllWindows()) {
+      if (!win.isDestroyed()) {
+        win.webContents.send(IpcChannels.SleepTimerOnTick, remainingMs);
+      }
+    }
+  });
+};

--- a/src/main/sleepTimer/SleepTimerService.test.ts
+++ b/src/main/sleepTimer/SleepTimerService.test.ts
@@ -1,0 +1,316 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ---- 用 vi.hoisted 提升 mock，确保 vi.mock 工厂函数可用 ----
+
+const { mockPause, mockStop, mockQuit } = vi.hoisted(() => ({
+  mockPause: vi.fn().mockResolvedValue({ state: 'paused' }),
+  mockStop: vi.fn().mockReturnValue(undefined),
+  mockQuit: vi.fn(),
+}));
+
+vi.mock('../audio/AudioSession', () => ({
+  getAudioSession: () => ({
+    pause: mockPause,
+    stop: mockStop,
+    getStatus: () => ({ state: 'playing' as const }),
+  }),
+}));
+
+vi.mock('electron', () => ({
+  app: {
+    quit: mockQuit,
+  },
+  BrowserWindow: {
+    getFocusedWindow: vi.fn().mockReturnValue(null),
+    getAllWindows: vi.fn().mockReturnValue([]),
+  },
+}));
+
+vi.mock('../app/dataProtection', () => ({
+  noteDataProtectionPlaybackActivity: vi.fn(),
+}));
+
+vi.mock('../integrations/smtc/SmtcStatusSync', () => ({
+  syncSmtcStatus: vi.fn(),
+}));
+
+vi.mock('../ipc/playbackIpc', () => ({
+  savePlaybackMemoryNow: vi.fn(),
+}));
+
+// ---- 导入被测模块 ----
+
+import { getSleepTimerService } from './SleepTimerService';
+
+describe('SleepTimerService', () => {
+  let service: ReturnType<typeof getSleepTimerService>;
+
+  beforeEach(() => {
+    service = getSleepTimerService();
+    service.dispose();
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    service.dispose();
+  });
+
+  // ---- 基本生命周期 ----
+
+  describe('基本生命周期', () => {
+    it('初始状态应为非活跃', () => {
+      const status = service.getStatus();
+      expect(status.isActive).toBe(false);
+      expect(status.remainingMs).toBe(0);
+      expect(status.action).toBe('pause');
+    });
+
+    it('启动后状态应为活跃', () => {
+      service.start({ durationMinutes: 5, action: 'pause', fadeOut: false });
+      const status = service.getStatus();
+      expect(status.isActive).toBe(true);
+      expect(status.remainingMs).toBeGreaterThan(0);
+      expect(status.action).toBe('pause');
+      expect(status.durationMinutes).toBe(5);
+    });
+
+    it('取消后状态应为非活跃', () => {
+      service.start({ durationMinutes: 5, action: 'pause', fadeOut: false });
+      service.cancel();
+      const status = service.getStatus();
+      expect(status.isActive).toBe(false);
+      expect(status.remainingMs).toBe(0);
+    });
+
+    it('重复 start 应覆盖前一个定时器', () => {
+      service.start({ durationMinutes: 5, action: 'pause', fadeOut: false });
+      service.start({ durationMinutes: 10, action: 'stop', fadeOut: false });
+      const status = service.getStatus();
+      expect(status.durationMinutes).toBe(10);
+      expect(status.action).toBe('stop');
+    });
+  });
+
+  // ---- 输入校验 ----
+
+  describe('输入校验', () => {
+    it('durationMinutes 为 0 时应抛出错误', () => {
+      expect(() => service.start({ durationMinutes: 0, action: 'pause', fadeOut: false }))
+        .toThrow('durationMinutes must be a positive finite number');
+    });
+
+    it('durationMinutes 为负数时应抛出错误', () => {
+      expect(() => service.start({ durationMinutes: -1, action: 'pause', fadeOut: false }))
+        .toThrow('durationMinutes must be a positive finite number');
+    });
+
+    it('durationMinutes 为 NaN 时应抛出错误', () => {
+      expect(() => service.start({ durationMinutes: NaN, action: 'pause', fadeOut: false }))
+        .toThrow('durationMinutes must be a positive finite number');
+    });
+
+    it('durationMinutes 为 Infinity 时应抛出错误', () => {
+      expect(() => service.start({ durationMinutes: Infinity, action: 'pause', fadeOut: false }))
+        .toThrow('durationMinutes must be a positive finite number');
+    });
+  });
+
+  // ---- 触发行为 ----
+
+  describe('触发行为', () => {
+    it('action 为 pause 时到期应调用 AudioSession.pause()', () => {
+      vi.useFakeTimers();
+      try {
+        service.start({ durationMinutes: 1, action: 'pause', fadeOut: false });
+        vi.advanceTimersByTime(60 * 1000 + 1500);
+        expect(mockPause).toHaveBeenCalledTimes(1);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('action 为 stop 时到期应调用 AudioSession.stop()', () => {
+      vi.useFakeTimers();
+      try {
+        service.start({ durationMinutes: 1, action: 'stop', fadeOut: false });
+        vi.advanceTimersByTime(60 * 1000 + 1500);
+        expect(mockStop).toHaveBeenCalledTimes(1);
+        expect(mockPause).not.toHaveBeenCalled();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('action 为 quit 时到期应调用 app.quit()', () => {
+      vi.useFakeTimers();
+      try {
+        service.start({ durationMinutes: 1, action: 'quit', fadeOut: false });
+        vi.advanceTimersByTime(60 * 1000 + 1500);
+        expect(mockQuit).toHaveBeenCalledTimes(1);
+        expect(mockPause).not.toHaveBeenCalled();
+        expect(mockStop).not.toHaveBeenCalled();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+  });
+
+  // ---- 回调机制 ----
+
+  describe('回调机制', () => {
+    it('onTick 应在每秒触发', () => {
+      vi.useFakeTimers();
+      try {
+        const tickFn = vi.fn();
+        service.onTick(tickFn);
+        service.start({ durationMinutes: 1, action: 'pause', fadeOut: false });
+        // start 立即触发一次 tick
+        expect(tickFn).toHaveBeenCalledTimes(1);
+        vi.advanceTimersByTime(1000);
+        expect(tickFn).toHaveBeenCalledTimes(2);
+        vi.advanceTimersByTime(1000);
+        expect(tickFn).toHaveBeenCalledTimes(3);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('onTick 返回的取消函数应停止接收回调', () => {
+      vi.useFakeTimers();
+      try {
+        const tickFn = vi.fn();
+        const unsubscribe = service.onTick(tickFn);
+        service.start({ durationMinutes: 1, action: 'pause', fadeOut: false });
+        expect(tickFn).toHaveBeenCalledTimes(1);
+        unsubscribe();
+        vi.advanceTimersByTime(1000);
+        expect(tickFn).toHaveBeenCalledTimes(1);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('onComplete 应在到期时触发', () => {
+      vi.useFakeTimers();
+      try {
+        const completeFn = vi.fn();
+        service.onComplete(completeFn);
+        service.start({ durationMinutes: 1, action: 'pause', fadeOut: false });
+        vi.advanceTimersByTime(60 * 1000 + 1500);
+        expect(completeFn).toHaveBeenCalledTimes(1);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('onChange 应在 start/cancel/tick 时触发', () => {
+      vi.useFakeTimers();
+      try {
+        const changeFn = vi.fn();
+        service.onChange(changeFn);
+        service.start({ durationMinutes: 1, action: 'pause', fadeOut: false });
+        expect(changeFn).toHaveBeenCalledTimes(1);
+        vi.advanceTimersByTime(1000);
+        expect(changeFn).toHaveBeenCalledTimes(2);
+        service.cancel();
+        expect(changeFn).toHaveBeenCalledTimes(3);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('到期时应触发 emitTick(0)', () => {
+      vi.useFakeTimers();
+      try {
+        const tickFn = vi.fn();
+        service.onTick(tickFn);
+        service.start({ durationMinutes: 1, action: 'pause', fadeOut: false });
+        vi.advanceTimersByTime(60 * 1000 + 1500);
+        const lastCall = tickFn.mock.calls[tickFn.mock.calls.length - 1];
+        expect(lastCall[0]).toBe(0);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+  });
+
+  // ---- 渐弱效果 ----
+
+  describe('渐弱效果', () => {
+    it('fadeOut 为 true 且 action 为 pause 时，到期应调用 pause()（pause 自带淡出）', () => {
+      vi.useFakeTimers();
+      try {
+        service.start({ durationMinutes: 1, action: 'pause', fadeOut: true });
+        vi.advanceTimersByTime(60 * 1000 + 1500);
+        expect(mockPause).toHaveBeenCalledTimes(1);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('fadeOut 为 true 且 action 为 stop 时，到期应先 pause() 再 stop()', async () => {
+      const completeFn = vi.fn();
+      service.onComplete(completeFn);
+      service.start({ durationMinutes: 0.001, action: 'stop', fadeOut: true });
+      // 等待定时器到期 + pause Promise resolve + stop 执行
+      await new Promise((resolve) => setTimeout(resolve, 3000));
+      // 验证 pause 被调用了
+      expect(mockPause).toHaveBeenCalled();
+      // 验证 complete 被触发了（说明定时器确实到期了）
+      expect(completeFn).toHaveBeenCalled();
+      // 验证 stop 在 pause 之后被调用
+      expect(mockStop).toHaveBeenCalledTimes(1);
+    });
+
+    it('fadeOut 为 true 且 action 为 quit 时，到期应先 pause() 再 quit()', async () => {
+      const completeFn = vi.fn();
+      service.onComplete(completeFn);
+      service.start({ durationMinutes: 0.001, action: 'quit', fadeOut: true });
+      await new Promise((resolve) => setTimeout(resolve, 3000));
+      expect(mockPause).toHaveBeenCalled();
+      expect(completeFn).toHaveBeenCalled();
+      expect(mockQuit).toHaveBeenCalledTimes(1);
+    });
+
+    it('fadeOut 为 false 且 action 为 stop 时，到期应直接 stop() 不经过 pause', () => {
+      vi.useFakeTimers();
+      try {
+        service.start({ durationMinutes: 1, action: 'stop', fadeOut: false });
+        vi.advanceTimersByTime(60 * 1000 + 1500);
+        expect(mockStop).toHaveBeenCalledTimes(1);
+        expect(mockPause).not.toHaveBeenCalled();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('getStatus 应反映 fadeOutEnabled 状态', () => {
+      service.start({ durationMinutes: 5, action: 'pause', fadeOut: true });
+      expect(service.getStatus().fadeOutEnabled).toBe(true);
+      service.cancel();
+      service.start({ durationMinutes: 5, action: 'pause', fadeOut: false });
+      expect(service.getStatus().fadeOutEnabled).toBe(false);
+    });
+  });
+
+  // ---- dispose ----
+
+  describe('dispose', () => {
+    it('dispose 后不应再触发回调', () => {
+      vi.useFakeTimers();
+      try {
+        const tickFn = vi.fn();
+        const completeFn = vi.fn();
+        service.onTick(tickFn);
+        service.onComplete(completeFn);
+        service.start({ durationMinutes: 1, action: 'pause', fadeOut: false });
+        service.dispose();
+        vi.advanceTimersByTime(120 * 1000);
+        expect(tickFn).toHaveBeenCalledTimes(1);
+        expect(completeFn).not.toHaveBeenCalled();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+  });
+});

--- a/src/main/sleepTimer/SleepTimerService.ts
+++ b/src/main/sleepTimer/SleepTimerService.ts
@@ -1,0 +1,382 @@
+import { app, BrowserWindow } from 'electron';
+import { getAudioSession } from '../audio/AudioSession';
+import { noteDataProtectionPlaybackActivity } from '../app/dataProtection';
+import { syncSmtcStatus } from '../integrations/smtc/SmtcStatusSync';
+import { savePlaybackMemoryNow } from '../ipc/playbackIpc';
+import type { SleepTimerAction, SleepTimerStatus, SleepTimerStartRequest } from '../../shared/types/sleepTimer';
+
+/** 睡眠定时器日志前缀 */
+const LOG_PREFIX = '[SleepTimer]';
+
+/** 睡眠定时器核心服务（单例） */
+class SleepTimerService {
+  /** 倒计时 interval 句柄 */
+  private intervalId: ReturnType<typeof setInterval> | null = null;
+
+  /** 倒计时开始时间戳 */
+  private startTimeMs = 0;
+
+  /** 总时长（毫秒） */
+  private totalDurationMs = 0;
+
+  /** 当前到期动作 */
+  private action: SleepTimerAction = 'pause';
+
+  /** 是否启用淡出 */
+  private fadeOutEnabled = false;
+
+  /** 设定时长（分钟） */
+  private durationMinutes = 0;
+
+  /** 每秒 tick 回调集合 */
+  private readonly tickCallbacks = new Set<(remainingMs: number) => void>();
+
+  /** 完成回调集合 */
+  private readonly completeCallbacks = new Set<() => void>();
+
+  /** 状态变更回调集合 */
+  private readonly changeCallbacks = new Set<(status: SleepTimerStatus) => void>();
+
+  /** 启动倒计时，如果已有运行中的定时器则覆盖 */
+  start(request: SleepTimerStartRequest): void {
+    // 校验时长
+    if (!Number.isFinite(request.durationMinutes) || request.durationMinutes <= 0) {
+      throw new Error('durationMinutes must be a positive finite number');
+    }
+
+    // 如果已有定时器在运行，先清理
+    this.clearInterval();
+
+    this.durationMinutes = request.durationMinutes;
+    this.action = request.action;
+    this.fadeOutEnabled = request.fadeOut;
+    this.totalDurationMs = request.durationMinutes * 60 * 1000;
+    this.startTimeMs = Date.now();
+
+    console.log(`${LOG_PREFIX} Started: ${request.durationMinutes}min, action=${request.action}, fadeOut=${request.fadeOut}`);
+
+    // 启动每秒 tick
+    this.intervalId = setInterval(() => {
+      this.tick();
+    }, 1000);
+
+    // 立即触发一次 onChange
+    this.emitChange();
+
+    // 立即触发一次 tick 回调
+    const remainingMs = this.getRemainingMs();
+    this.emitTick(remainingMs);
+  }
+
+  /** 取消定时器，清理所有 interval 和状态 */
+  cancel(): void {
+    console.log(`${LOG_PREFIX} Cancelled`);
+    this.clearInterval();
+    this.resetState();
+    this.emitChange();
+  }
+
+  /** 返回当前状态 */
+  getStatus(): SleepTimerStatus {
+    return {
+      isActive: this.intervalId !== null,
+      remainingMs: this.getRemainingMs(),
+      action: this.action,
+      fadeOutEnabled: this.fadeOutEnabled,
+      durationMinutes: this.durationMinutes,
+    };
+  }
+
+  /** 注册每秒回调，返回取消函数 */
+  onTick(callback: (remainingMs: number) => void): () => void {
+    this.tickCallbacks.add(callback);
+    return () => {
+      this.tickCallbacks.delete(callback);
+    };
+  }
+
+  /** 注册完成回调，返回取消函数 */
+  onComplete(callback: () => void): () => void {
+    this.completeCallbacks.add(callback);
+    return () => {
+      this.completeCallbacks.delete(callback);
+    };
+  }
+
+  /** 注册状态变更回调，返回取消函数 */
+  onChange(callback: (status: SleepTimerStatus) => void): () => void {
+    this.changeCallbacks.add(callback);
+    return () => {
+      this.changeCallbacks.delete(callback);
+    };
+  }
+
+  /** 完全清理（应用退出时调用） */
+  dispose(): void {
+    this.clearInterval();
+    this.resetState();
+    this.tickCallbacks.clear();
+    this.completeCallbacks.clear();
+    this.changeCallbacks.clear();
+  }
+
+  // ---- 内部方法 ----
+
+  /** 每秒 tick 处理 */
+  private tick(): void {
+    const remainingMs = this.getRemainingMs();
+
+    if (remainingMs <= 0) {
+      console.log(`${LOG_PREFIX} Timer expired (0s remaining), executing action...`);
+      // 倒计时结束，先通知渲染进程剩余时间为 0
+      this.emitTick(0);
+      this.executeAction();
+      this.clearInterval();
+      this.resetState();
+      this.emitComplete();
+      this.emitChange();
+      return;
+    }
+
+    this.emitTick(remainingMs);
+    this.emitChange();
+  }
+
+  /** 根据动作执行对应操作（支持渐弱） */
+  private executeAction(): void {
+    const action = this.action;
+    console.log(`${LOG_PREFIX} Timer expired, executing action: ${action}, fadeOut: ${this.fadeOutEnabled}`);
+
+    if (action === 'pause') {
+      // 策略：优先通过渲染进程执行（与点击暂停按钮同一路径）
+      // 回退：直接调用主进程 AudioSession
+      this.pauseViaRenderer().then(() => {
+        console.log(`${LOG_PREFIX} Renderer pause resolved`);
+      }).catch((err) => {
+        console.warn(`${LOG_PREFIX} Renderer pause failed, falling back to direct AudioSession:`, err);
+        this.doPause();
+      });
+    } else if (this.fadeOutEnabled) {
+      // 渐弱模式：先通过渲染进程暂停，完成后再执行最终动作
+      this.pauseViaRenderer().then(() => {
+        console.log(`${LOG_PREFIX} Fade-out pause completed via renderer, executing final action: ${action}`);
+        this.executeFinalAction(action);
+      }).catch((err) => {
+        console.warn(`${LOG_PREFIX} Renderer fade-out pause failed, trying direct then final action:`, err);
+        this.doPause().finally(() => this.executeFinalAction(action));
+      });
+    } else {
+      this.executeFinalAction(action);
+    }
+  }
+
+  /**
+   * 通过渲染进程触发暂停（多策略回退）
+   *
+   * 策略优先级：
+   *   1. window.echo.audio.pause() — IPC 标准路径
+   *   2. 点击播放栏暂停按钮 — DOM 模拟用户操作
+   *   3. getAudioSession().pause() — 主进程直接调用
+   */
+  private pauseViaRenderer(): Promise<void> {
+    const win = BrowserWindow.getFocusedWindow() ?? BrowserWindow.getAllWindows()[0];
+    if (!win || win.isDestroyed()) {
+      console.warn(`${LOG_PREFIX} No available BrowserWindow, falling back to direct pause`);
+      return this.doPause();
+    }
+
+    console.log(`${LOG_PREFIX} Attempting pause via renderer (strategy: echo.audio.pause)`);
+
+    // 策略 1: 标准 API 调用
+    return win.webContents.executeJavaScript('window.echo.audio.pause()')
+      .then(() => {
+        console.log(`${LOG_PREFIX} Strategy 1 (echo.audio.pause): success`);
+      })
+      .catch((err1) => {
+        console.warn(`${LOG_PREFIX} Strategy 1 failed:`, err1?.message || err1);
+
+        // 策略 2: DOM 模拟点击暂停按钮
+        console.log(`${LOG_PREFIX} Trying strategy 2: DOM button click`);
+        return win.webContents.executeJavaScript(`
+          (() => {
+            // 查找播放栏中的暂停按钮（通常有 data-action="pause" 或特定 class）
+            const btn = document.querySelector('[data-action="pause"]')
+              || document.querySelector('.transport-btn-pause')
+              || document.querySelector('button[aria-label*="pause" i]')
+              || document.querySelector('button[title*="pause" i]');
+            if (btn) { btn.click(); return 'clicked'; }
+            // 如果找不到暂停按钮，尝试查找当前播放/暂停切换按钮
+            const toggleBtn = document.querySelector('[data-action="toggle-playback"]')
+              || document.querySelector('.play-pause-btn');
+            if (toggleBtn) { toggleBtn.click(); return 'clicked-toggle'; }
+            return 'no-button-found';
+          })()
+        `).then((result: string) => {
+          console.log(`${LOG_PREFIX} Strategy 2 (DOM click): ${result}`);
+          if (result === 'no-button-found') {
+            throw new Error('No pause button found in DOM');
+          }
+        }).catch((err2) => {
+          console.warn(`${LOG_PREFIX} Strategy 2 failed:`, err2?.message || err2);
+
+          // 策略 3: 回退到主进程直接调用
+          console.log(`${LOG_PREFIX} Trying strategy 3: direct AudioSession.pause()`);
+          return this.doPause();
+        });
+      });
+  }
+
+  /**
+   * 直接调用播放控制管线暂停音频
+   * 与 playback:pause IPC handler 走同一条路径：
+   *   数据保护标记 → AudioSession.pause() → 保存播放记忆 → SMTC 同步
+   */
+  private async doPause(): Promise<void> {
+    const session = getAudioSession();
+    const beforeState = session.getStatus().state;
+    console.log(`${LOG_PREFIX} doPause: audioState before="${beforeState}"`);
+
+    // 标记数据保护活动停止
+    try {
+      noteDataProtectionPlaybackActivity(false);
+    } catch (err) {
+      console.warn(`${LOG_PREFIX} noteDataProtectionPlaybackActivity failed:`, err);
+    }
+
+    // 执行暂停
+    const status = await session.pause();
+    console.log(`${LOG_PREFIX} doPause: audioSession.pause() resolved, newState="${status.state}"`);
+
+    // 保存播放记忆（恢复位置等）
+    try {
+      savePlaybackMemoryNow();
+    } catch (err) {
+      console.warn(`${LOG_PREFIX} savePlaybackMemoryNow failed:`, err);
+    }
+
+    // 同步系统媒体传输控制（Windows 音量混合器等）
+    try {
+      syncSmtcStatus();
+    } catch (err) {
+      console.warn(`${LOG_PREFIX} syncSmtcStatus failed:`, err);
+    }
+
+    console.log(`${LOG_PREFIX} doPause: complete`);
+  }
+
+  /**
+   * 直接调用播放控制管线停止音频
+   * 与 playback:stop IPC handler 同路径
+   */
+  private doStop(): void {
+    const session = getAudioSession();
+    console.log(`${LOG_PREFIX} doStop: audioState before="${session.getStatus().state}"`);
+
+    try {
+      noteDataProtectionPlaybackActivity(false);
+    } catch (err) {
+      console.warn(`${LOG_PREFIX} noteDataProtectionPlaybackActivity failed:`, err);
+    }
+
+    session.stop();
+
+    try {
+      savePlaybackMemoryNow();
+    } catch (err) {
+      console.warn(`${LOG_PREFIX} savePlaybackMemoryNow failed:`, err);
+    }
+
+    try {
+      syncSmtcStatus();
+    } catch (err) {
+      console.warn(`${LOG_PREFIX} syncSmtcStatus failed:`, err);
+    }
+
+    console.log(`${LOG_PREFIX} doStop: complete`);
+  }
+
+  /** 执行最终动作（stop 或 quit） */
+  private executeFinalAction(action: SleepTimerAction): void {
+    switch (action) {
+      case 'stop':
+        this.doStop();
+        break;
+      case 'quit':
+        app.quit();
+        break;
+      // pause 不应到达这里
+    }
+  }
+
+  /** 计算剩余毫秒数 */
+  private getRemainingMs(): number {
+    if (this.intervalId === null) {
+      return 0;
+    }
+    const elapsed = Date.now() - this.startTimeMs;
+    return Math.max(0, this.totalDurationMs - elapsed);
+  }
+
+  /** 清理 interval */
+  private clearInterval(): void {
+    if (this.intervalId !== null) {
+      globalThis.clearInterval(this.intervalId);
+      this.intervalId = null;
+    }
+  }
+
+  /** 重置内部状态 */
+  private resetState(): void {
+    this.startTimeMs = 0;
+    this.totalDurationMs = 0;
+    this.action = 'pause';
+    this.fadeOutEnabled = false;
+    this.durationMinutes = 0;
+  }
+
+  /** 触发所有 tick 回调 */
+  private emitTick(remainingMs: number): void {
+    for (const callback of this.tickCallbacks) {
+      try {
+        callback(remainingMs);
+      } catch {
+        // 回调异常不影响其他回调
+      }
+    }
+  }
+
+  /** 触发所有完成回调 */
+  private emitComplete(): void {
+    for (const callback of this.completeCallbacks) {
+      try {
+        callback();
+      } catch {
+        // 回调异常不影响其他回调
+      }
+    }
+  }
+
+  /** 触发所有状态变更回调 */
+  private emitChange(): void {
+    const status = this.getStatus();
+    for (const callback of this.changeCallbacks) {
+      try {
+        callback(status);
+      } catch {
+        // 回调异常不影响其他回调
+      }
+    }
+  }
+}
+
+// ---- 单例导出 ----
+
+let instance: SleepTimerService | null = null;
+
+/** 获取睡眠定时器服务单例 */
+export const getSleepTimerService = (): SleepTimerService => {
+  if (instance === null) {
+    instance = new SleepTimerService();
+  }
+  return instance;
+};

--- a/src/preload/apiTypes.ts
+++ b/src/preload/apiTypes.ts
@@ -271,6 +271,7 @@ import type {
   StreamingTrackLikedResult,
   StreamingTrackSourceInfo,
 } from '../shared/types/streaming';
+import type { SleepTimerStartRequest, SleepTimerStatus } from '../shared/types/sleepTimer';
 
 export type FontFileAsset = {
   path: string;
@@ -826,6 +827,12 @@ export type EchoApi = {
     setRoomCorrectionEnabled: (enabled: boolean) => Promise<RoomCorrectionState>;
     setRoomCorrectionTrim: (trimDb: number) => Promise<RoomCorrectionState>;
     clearRoomCorrection: () => Promise<RoomCorrectionState>;
+  };
+  sleepTimer: {
+    start: (request: SleepTimerStartRequest) => Promise<SleepTimerStatus>;
+    cancel: () => Promise<SleepTimerStatus>;
+    getStatus: () => Promise<SleepTimerStatus>;
+    onTick: (handler: (remainingMs: number) => void) => () => void;
   };
 };
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -15,6 +15,7 @@ import type { SmtcCommand, SmtcLyricsProgress } from '../shared/types/smtc';
 import type { UpdateStatus } from '../shared/types/updates';
 import type { DiagnosticConsoleEntry } from '../shared/types/diagnostics';
 import type { DataBackupProgress } from '../shared/types/settingsBackup';
+import type { SleepTimerStatus, SleepTimerStartRequest } from '../shared/types/sleepTimer';
 import { calculateReplayGain, dbToLinearGain, type ReplayGainCalculation, type ReplayGainTrackData } from '../shared/utils/replayGain';
 import { DEFAULT_REPLAY_GAIN_TARGET_LUFS } from '../shared/constants/replayGain';
 
@@ -2396,6 +2397,18 @@ const echoApi: EchoApi = {
     setRoomCorrectionEnabled: (enabled) => ipcRenderer.invoke(IpcChannels.RoomCorrectionSetEnabled, enabled) as Promise<RoomCorrectionState>,
     setRoomCorrectionTrim: (trimDb) => ipcRenderer.invoke(IpcChannels.RoomCorrectionSetTrim, trimDb) as Promise<RoomCorrectionState>,
     clearRoomCorrection: () => ipcRenderer.invoke(IpcChannels.RoomCorrectionClear) as Promise<RoomCorrectionState>,
+  },
+  sleepTimer: {
+    start: (request) => ipcRenderer.invoke(IpcChannels.SleepTimerStart, request),
+    cancel: () => ipcRenderer.invoke(IpcChannels.SleepTimerCancel),
+    getStatus: () => ipcRenderer.invoke(IpcChannels.SleepTimerGetStatus),
+    onTick: (handler) => {
+      const listener = (_event: Electron.IpcRendererEvent, remainingMs: unknown): void => {
+        handler(typeof remainingMs === 'number' ? remainingMs : 0);
+      };
+      ipcRenderer.on(IpcChannels.SleepTimerOnTick, listener);
+      return () => ipcRenderer.off(IpcChannels.SleepTimerOnTick, listener);
+    },
   },
 };
 

--- a/src/renderer/components/player/PlayerTransport.tsx
+++ b/src/renderer/components/player/PlayerTransport.tsx
@@ -12,6 +12,7 @@ import {
   SkipForward,
 } from 'lucide-react';
 import type { RepeatMode } from '../../stores/PlaybackQueueProvider';
+import { SleepTimerButton } from './SleepTimerButton';
 
 type PlayerTransportProps = {
   isPlaying: boolean;
@@ -104,5 +105,6 @@ export const PlayerTransport = ({
     <button className="icon-button" type="button" aria-label="MV" title="MV" onClick={onOpenMv}>
       <Film size={17} />
     </button>
+    <SleepTimerButton />
   </div>
 );

--- a/src/renderer/components/player/SleepTimerButton.tsx
+++ b/src/renderer/components/player/SleepTimerButton.tsx
@@ -1,0 +1,131 @@
+import { useState, useEffect, useCallback, useRef } from 'react';
+import { Timer } from 'lucide-react';
+import { SleepTimerPopover } from './SleepTimerPopover';
+import { useI18n } from '../../i18n/I18nProvider';
+
+const POPOVER_EXIT_MS = 180;
+const POPOVER_CLOSE_DISTANCE_PX = 150;
+
+/** 计算 point 到 rect 的最近距离 */
+const distanceFromRect = (x: number, y: number, rect: DOMRect): number => {
+  const dx = x < rect.left ? rect.left - x : x > rect.right ? x - rect.right : 0;
+  const dy = y < rect.top ? rect.top - y : y > rect.bottom ? y - rect.bottom : 0;
+  return Math.hypot(dx, dy);
+};
+
+/**
+ * 睡眠定时器按钮组件
+ * - 空闲态：显示定时器图标
+ * - 运行态：显示 MM:SS 倒计时
+ * - 点击弹出 Popover（带入场/退场动画 + 点击外部关闭）
+ */
+export const SleepTimerButton = (): JSX.Element => {
+  const { t } = useI18n();
+  const [isActive, setIsActive] = useState(false);
+  const [remainingMs, setRemainingMs] = useState(0);
+  const [showPopover, setShowPopover] = useState(false);
+  const [shouldRender, setShouldRender] = useState(false);
+  const [isVisible, setIsVisible] = useState(false);
+
+  const rootRef = useRef<HTMLDivElement>(null);
+  const popoverRef = useRef<HTMLDivElement>(null);
+
+  // Popover 入场/退场动画控制
+  useEffect(() => {
+    if (showPopover) {
+      setShouldRender(true);
+      const frame = window.requestAnimationFrame(() => setIsVisible(true));
+      return () => window.cancelAnimationFrame(frame);
+    }
+    setIsVisible(false);
+    if (!shouldRender) return undefined;
+    const timer = window.setTimeout(() => setShouldRender(false), POPOVER_EXIT_MS);
+    return () => window.clearTimeout(timer);
+  }, [showPopover, shouldRender]);
+
+  // 点击外部自动关闭 Popover（与 VolumeControl 相同模式）
+  useEffect(() => {
+    if (!showPopover) return undefined;
+
+    const handlePointerMove = (event: PointerEvent): void => {
+      const rects = [rootRef.current?.getBoundingClientRect(), popoverRef.current?.getBoundingClientRect()].filter(
+        (r): r is DOMRect => Boolean(r),
+      );
+      const nearestDistance = Math.min(...rects.map((rect) => distanceFromRect(event.clientX, event.clientY, rect)));
+      if (nearestDistance > POPOVER_CLOSE_DISTANCE_PX) {
+        setShowPopover(false);
+      }
+    };
+
+    const handlePointerDown = (event: PointerEvent): void => {
+      if (rootRef.current?.contains(event.target as Node)) return;
+      setShowPopover(false);
+    };
+
+    window.addEventListener('pointermove', handlePointerMove, true);
+    window.addEventListener('pointerdown', handlePointerDown, true);
+    return () => {
+      window.removeEventListener('pointermove', handlePointerMove, true);
+      window.removeEventListener('pointerdown', handlePointerDown, true);
+    };
+  }, [showPopover]);
+
+  // 监听定时器 tick 事件
+  useEffect(() => {
+    // 防御性检查：确保 preload 已正确暴露 sleepTimer API
+    if (!window.echo?.sleepTimer) {
+      console.warn('[SleepTimerButton] window.echo.sleepTimer is not available. Available keys:', window.echo ? Object.keys(window.echo) : 'window.echo is undefined');
+      return undefined;
+    }
+    const unsubscribe = window.echo.sleepTimer.onTick((ms) => {
+      setRemainingMs(ms);
+      setIsActive(ms > 0);
+    });
+    return unsubscribe;
+  }, []);
+
+  // 初始化时获取一次状态
+  useEffect(() => {
+    if (!window.echo?.sleepTimer) return;
+    window.echo.sleepTimer.getStatus().then((status) => {
+      setIsActive(status.isActive);
+      setRemainingMs(status.remainingMs);
+    }).catch(() => {});
+  }, []);
+
+  const formatTime = useCallback((ms: number): string => {
+    const totalSeconds = Math.ceil(ms / 1000);
+    const minutes = Math.floor(totalSeconds / 60);
+    const seconds = totalSeconds % 60;
+    return `${minutes.toString().padStart(2, '0')}:${seconds.toString().padStart(2, '0')}`;
+  }, []);
+
+  const handleTogglePopover = useCallback(() => {
+    setShowPopover((prev) => !prev);
+  }, []);
+
+  const handleClosePopover = useCallback(() => {
+    setShowPopover(false);
+  }, []);
+
+  return (
+    <div className="sleep-timer-control" ref={rootRef}>
+      <button
+        className={`icon-button ${isActive ? 'is-soft-active' : ''}`}
+        type="button"
+        aria-label={isActive ? t('sleepTimer.status.active', { time: formatTime(remainingMs) }) : t('sleepTimer.title')}
+        title={isActive ? t('sleepTimer.status.active', { time: formatTime(remainingMs) }) : t('sleepTimer.title')}
+        onClick={handleTogglePopover}
+      >
+        {isActive ? (
+          <span className="sleep-timer-countdown">{formatTime(remainingMs)}</span>
+        ) : (
+          <Timer size={17} />
+        )}
+      </button>
+      {shouldRender && (
+        <SleepTimerPopover onClose={handleClosePopover} isVisible={isVisible} ref={popoverRef} />
+      )}
+    </div>
+  );
+};

--- a/src/renderer/components/player/SleepTimerPopover.tsx
+++ b/src/renderer/components/player/SleepTimerPopover.tsx
@@ -1,0 +1,176 @@
+import { useState, useEffect, useCallback, forwardRef } from 'react';
+import type { SleepTimerAction, SleepTimerStatus } from '../../../shared/types/sleepTimer';
+import { useI18n } from '../../i18n/I18nProvider';
+
+/** 预设时长（分钟） */
+const PRESET_MINUTES = [5, 10, 15, 30, 45, 60] as const;
+
+/** 触发行为 key 映射 */
+const ACTION_KEYS: { value: SleepTimerAction; key: 'sleepTimer.action.pause' | 'sleepTimer.action.stop' | 'sleepTimer.action.quit' }[] = [
+  { value: 'pause', key: 'sleepTimer.action.pause' },
+  { value: 'stop', key: 'sleepTimer.action.stop' },
+  { value: 'quit', key: 'sleepTimer.action.quit' },
+];
+
+type SleepTimerPopoverProps = {
+  onClose: () => void;
+  isVisible: boolean;
+};
+
+/**
+ * 睡眠定时器弹出面板
+ * - 空闲态：显示行为选择 + 预设时长按钮
+ * - 运行态：显示倒计时 + 取消按钮
+ *
+ * 样式由外部 `.sleep-timer-popover` CSS 类控制（定义在 app.css）
+ */
+export const SleepTimerPopover = forwardRef<HTMLDivElement, SleepTimerPopoverProps>(
+  ({ onClose, isVisible }, ref): JSX.Element => {
+  const { t } = useI18n();
+  const [status, setStatus] = useState<SleepTimerStatus | null>(null);
+  const [selectedAction, setSelectedAction] = useState<SleepTimerAction>('pause');
+  const [fadeOutEnabled, setFadeOutEnabled] = useState(true);
+  const [customMinutes, setCustomMinutes] = useState('');
+
+  /** 自定义时长是否有效（1-120 分钟） */
+  const parsedMinutes = parseInt(customMinutes, 10);
+  const isCustomValid = customMinutes !== '' && Number.isFinite(parsedMinutes) && parsedMinutes >= 1 && parsedMinutes <= 120;
+
+  // 获取初始状态
+  useEffect(() => {
+    window.echo.sleepTimer.getStatus().then((s) => {
+      setStatus(s);
+      if (s.isActive) {
+        setSelectedAction(s.action);
+        setFadeOutEnabled(s.fadeOutEnabled);
+      }
+    }).catch(() => {});
+  }, []);
+
+  // 监听 tick 更新
+  useEffect(() => {
+    const unsubscribe = window.echo.sleepTimer.onTick((remainingMs) => {
+      setStatus((prev: SleepTimerStatus | null) => prev ? { ...prev, remainingMs, isActive: remainingMs > 0 } : prev);
+    });
+    return unsubscribe;
+  }, []);
+
+  const handleStart = useCallback(async (minutes: number) => {
+    const newStatus = await window.echo.sleepTimer.start({
+      durationMinutes: minutes,
+      action: selectedAction,
+      fadeOut: fadeOutEnabled,
+    });
+    setStatus(newStatus);
+    setCustomMinutes('');
+  }, [selectedAction, fadeOutEnabled]);
+
+  const handleCustomStart = useCallback(() => {
+    if (isCustomValid) {
+      handleStart(parsedMinutes);
+    }
+  }, [isCustomValid, parsedMinutes, handleStart]);
+
+  const handleCancel = useCallback(async () => {
+    const newStatus = await window.echo.sleepTimer.cancel();
+    setStatus(newStatus);
+  }, []);
+
+  const formatTime = (ms: number): string => {
+    const totalSeconds = Math.ceil(ms / 1000);
+    const minutes = Math.floor(totalSeconds / 60);
+    const seconds = totalSeconds % 60;
+    return `${minutes.toString().padStart(2, '0')}:${seconds.toString().padStart(2, '0')}`;
+  };
+
+  /** 获取 action 的翻译标签 */
+  const getActionLabel = (action: SleepTimerAction): string => {
+    const mapping: Record<SleepTimerAction, 'sleepTimer.action.pause' | 'sleepTimer.action.stop' | 'sleepTimer.action.quit'> = {
+      pause: 'sleepTimer.action.pause',
+      stop: 'sleepTimer.action.stop',
+      quit: 'sleepTimer.action.quit',
+    };
+    return t(mapping[action]);
+  };
+
+  return (
+    <div ref={ref} className="sleep-timer-popover" data-open={isVisible}>
+      {/* 标题 */}
+      <div className="st-popover-title">{t('sleepTimer.title')}</div>
+
+      {status?.isActive ? (
+        /* 运行态：倒计时 + 取消 */
+        <div className="st-popover-running">
+          <span className="st-countdown">{formatTime(status.remainingMs)}</span>
+          <span className="st-hint">{t('sleepTimer.afterAction', { action: getActionLabel(status.action) })}</span>
+          <button className="st-cancel-btn icon-button" type="button" onClick={handleCancel}>
+            {t('sleepTimer.status.cancel')}
+          </button>
+        </div>
+      ) : (
+        /* 空闲态：设置面板 */
+        <>
+          {/* 行为选择 */}
+          <div className="st-action-bar">
+            {ACTION_KEYS.map((opt) => (
+              <button
+                key={opt.value}
+                className={`st-action-btn ${selectedAction === opt.value ? 'is-active' : ''}`}
+                type="button"
+                onClick={() => setSelectedAction(opt.value)}
+              >
+                {t(opt.key)}
+              </button>
+            ))}
+          </div>
+
+          {/* 渐弱开关 */}
+          <label className="st-fade-row">
+            <span className="st-label">{t('sleepTimer.fadeOut.label')}</span>
+            <div className={`st-toggle ${fadeOutEnabled ? 'is-on' : ''}`} onClick={() => setFadeOutEnabled((prev) => !prev)}>
+              <span className="st-toggle-knob" />
+            </div>
+          </label>
+
+          {/* 预设时长网格 */}
+          <div className="st-preset-grid">
+            {PRESET_MINUTES.map((minutes) => (
+              <button
+                key={minutes}
+                className="st-preset-btn"
+                type="button"
+                onClick={() => handleStart(minutes)}
+              >
+                {t(`sleepTimer.preset.${minutes}` as 'sleepTimer.preset.5' | 'sleepTimer.preset.10' | 'sleepTimer.preset.15' | 'sleepTimer.preset.30' | 'sleepTimer.preset.45' | 'sleepTimer.preset.60')}
+              </button>
+            ))}
+          </div>
+
+          {/* 自定义时长输入行 */}
+          <div className="st-custom-row">
+            <input
+              type="number"
+              min={1}
+              max={120}
+              value={customMinutes}
+              onChange={(e) => setCustomMinutes(e.target.value)}
+              onKeyDown={(e) => { if (e.key === 'Enter') handleCustomStart(); }}
+              placeholder="--"
+              aria-label={t('sleepTimer.custom.unit')}
+              className="st-input"
+            />
+            <span className="st-unit">{t('sleepTimer.custom.unit')}</span>
+            <button
+              className="st-confirm-btn"
+              type="button"
+              onClick={handleCustomStart}
+              disabled={!isCustomValid}
+            >
+              {t('sleepTimer.custom.confirm')}
+            </button>
+          </div>
+        </>
+      )}
+    </div>
+  );
+});

--- a/src/renderer/i18n/locales.ts
+++ b/src/renderer/i18n/locales.ts
@@ -1,4 +1,4 @@
-﻿export type Locale = 'zh-CN' | 'zh-TW' | 'ja-JP' | 'en-US';
+export type Locale = 'zh-CN' | 'zh-TW' | 'ja-JP' | 'en-US';
 
 export const localeOptions: Array<{ locale: Locale; label: string }> = [
   { locale: 'zh-CN', label: '简体中文' },
@@ -3144,6 +3144,24 @@ export type TranslationKey =
   | 'segmentLoop.empty'
   | 'segmentLoop.notSet'
   | 'spotifyPlayback.error.noDevice'
+  | 'sleepTimer.title'
+  | 'sleepTimer.action.pause'
+  | 'sleepTimer.action.stop'
+  | 'sleepTimer.action.quit'
+  | 'sleepTimer.fadeOut.label'
+  | 'sleepTimer.custom.placeholder'
+  | 'sleepTimer.custom.unit'
+  | 'sleepTimer.custom.confirm'
+  | 'sleepTimer.status.active'
+  | 'sleepTimer.status.inactive'
+  | 'sleepTimer.status.cancel'
+  | 'sleepTimer.preset.5'
+  | 'sleepTimer.preset.10'
+  | 'sleepTimer.preset.15'
+  | 'sleepTimer.preset.30'
+  | 'sleepTimer.preset.45'
+  | 'sleepTimer.preset.60'
+  | 'sleepTimer.afterAction'
   | 'spotifyPlayback.error.noDrmKeysystem';
 
 type TranslationMap = Record<TranslationKey, string>;
@@ -6277,6 +6295,24 @@ const zhCN: TranslationMap = {
   'segmentLoop.empty': '保存片段后会显示在这里',
   'segmentLoop.notSet': '未设置',
   'spotifyPlayback.error.noDevice': '没有可用的 Spotify 播放设备。请开启“自动启动官方播放器”，或先打开 Spotify 桌面端/网页版。{hint}',
+  'sleepTimer.title': '睡眠定时器',
+  'sleepTimer.action.pause': '暂停',
+  'sleepTimer.action.stop': '停止',
+  'sleepTimer.action.quit': '退出',
+  'sleepTimer.fadeOut.label': '触发前渐弱',
+  'sleepTimer.custom.placeholder': '1-120',
+  'sleepTimer.custom.unit': '分钟',
+  'sleepTimer.custom.confirm': '确定',
+  'sleepTimer.status.active': '剩余 {time}',
+  'sleepTimer.status.inactive': '未启动',
+  'sleepTimer.status.cancel': '取消定时器',
+  'sleepTimer.preset.5': '5分钟',
+  'sleepTimer.preset.10': '10分钟',
+  'sleepTimer.preset.15': '15分钟',
+  'sleepTimer.preset.30': '30分钟',
+  'sleepTimer.preset.45': '45分钟',
+  'sleepTimer.preset.60': '60分钟',
+  'sleepTimer.afterAction': '到期后{action}',
   'spotifyPlayback.error.noDrmKeysystem': '当前 Electron 构建没有可用的 DRM/Widevine keysystem，Spotify 官方播放器无法在 ECHO 内注册设备。',
 };
 
@@ -8810,6 +8846,24 @@ const zhTW: TranslationMap = {
   'segmentLoop.empty': '儲存片段後會顯示在這裡',
   'segmentLoop.notSet': '未設定',
   'spotifyPlayback.error.noDevice': '沒有可用的 Spotify 播放裝置。請開啟「自動啟動官方播放器」，或先打開 Spotify 桌面端/網頁版。{hint}',
+  'sleepTimer.title': '睡眠定時器',
+  'sleepTimer.action.pause': '暫停',
+  'sleepTimer.action.stop': '停止',
+  'sleepTimer.action.quit': '退出',
+  'sleepTimer.fadeOut.label': '觸發前漸弱',
+  'sleepTimer.custom.placeholder': '1-120',
+  'sleepTimer.custom.unit': '分鐘',
+  'sleepTimer.custom.confirm': '確定',
+  'sleepTimer.status.active': '剩餘 {time}',
+  'sleepTimer.status.inactive': '未啟動',
+  'sleepTimer.status.cancel': '取消定時器',
+  'sleepTimer.preset.5': '5分鐘',
+  'sleepTimer.preset.10': '10分鐘',
+  'sleepTimer.preset.15': '15分鐘',
+  'sleepTimer.preset.30': '30分鐘',
+  'sleepTimer.preset.45': '45分鐘',
+  'sleepTimer.preset.60': '60分鐘',
+  'sleepTimer.afterAction': '到期後{action}',
   'spotifyPlayback.error.noDrmKeysystem': '目前 Electron 建置沒有可用的 DRM/Widevine keysystem，Spotify 官方播放器無法在 ECHO 內註冊裝置。',
   'settings.eq.ab.summary': '{preset} / 峰值 {peak} / 輸出 {output} / 前級 {preamp}',
   'settings.eq.level.clips': '削波 {count}',
@@ -11734,6 +11788,24 @@ const jaJP: TranslationMap = {
   'segmentLoop.empty': '区間を保存するとここに表示されます',
   'segmentLoop.notSet': '未設定',
   'spotifyPlayback.error.noDevice': '利用可能な Spotify 再生デバイスがありません。「公式プレイヤーを自動起動」を有効にするか、Spotify デスクトップ版または Web 版を先に開いてください。{hint}',
+  'sleepTimer.title': 'スリープタイマー',
+  'sleepTimer.action.pause': '一時停止',
+  'sleepTimer.action.stop': '停止',
+  'sleepTimer.action.quit': '終了',
+  'sleepTimer.fadeOut.label': 'フェードアウト',
+  'sleepTimer.custom.placeholder': '1-120',
+  'sleepTimer.custom.unit': '分',
+  'sleepTimer.custom.confirm': '確定',
+  'sleepTimer.status.active': '残り {time}',
+  'sleepTimer.status.inactive': '未設定',
+  'sleepTimer.status.cancel': 'タイマーをキャンセル',
+  'sleepTimer.preset.5': '5分',
+  'sleepTimer.preset.10': '10分',
+  'sleepTimer.preset.15': '15分',
+  'sleepTimer.preset.30': '30分',
+  'sleepTimer.preset.45': '45分',
+  'sleepTimer.preset.60': '60分',
+  'sleepTimer.afterAction': '終了後{action}',
   'spotifyPlayback.error.noDrmKeysystem': '現在の Electron ビルドには利用可能な DRM/Widevine keysystem がないため、Spotify 公式プレイヤーを ECHO 内でデバイス登録できません。',
   'settings.appearance.theme.title': 'テーマ',
   'settings.appearance.theme.description': 'ライト、ダーク、またはシステム設定に合わせます。',
@@ -14841,6 +14913,24 @@ const enUS: TranslationMap = {
   'segmentLoop.empty': 'Saved segments will appear here',
   'segmentLoop.notSet': 'Not set',
   'spotifyPlayback.error.noDevice': 'No Spotify playback device is available. Enable "auto-launch official player", or open Spotify desktop/web first.{hint}',
+  'sleepTimer.title': 'Sleep Timer',
+  'sleepTimer.action.pause': 'Pause',
+  'sleepTimer.action.stop': 'Stop',
+  'sleepTimer.action.quit': 'Quit',
+  'sleepTimer.fadeOut.label': 'Fade out before trigger',
+  'sleepTimer.custom.placeholder': '1-120',
+  'sleepTimer.custom.unit': 'min',
+  'sleepTimer.custom.confirm': 'OK',
+  'sleepTimer.status.active': '{time} remaining',
+  'sleepTimer.status.inactive': 'Not set',
+  'sleepTimer.status.cancel': 'Cancel timer',
+  'sleepTimer.preset.5': '5 min',
+  'sleepTimer.preset.10': '10 min',
+  'sleepTimer.preset.15': '15 min',
+  'sleepTimer.preset.30': '30 min',
+  'sleepTimer.preset.45': '45 min',
+  'sleepTimer.preset.60': '60 min',
+  'sleepTimer.afterAction': '{action} after timer',
   'spotifyPlayback.error.noDrmKeysystem': 'This Electron build has no available DRM/Widevine keysystem, so the official Spotify player cannot register a device inside ECHO.',
   'settings.appearance.theme.title': 'Theme',
   'settings.appearance.theme.description': 'Choose light, dark, or follow the system appearance.',

--- a/src/renderer/styles/app.css
+++ b/src/renderer/styles/app.css
@@ -7211,6 +7211,322 @@
   background: var(--volume-popover-active-hover-bg);
 }
 
+/* ============================================================
+   Sleep Timer Popover
+   ============================================================ */
+
+.sleep-timer-control {
+  position: relative;
+  z-index: 1;
+}
+
+/* 运行态按钮：倒计时文字模式，覆盖 icon-button 圆形固定尺寸 */
+.sleep-timer-control .icon-button.is-soft-active {
+  width: auto !important;
+  min-width: 44px;
+  height: 30px !important;
+  border-radius: 8px !important;
+  padding: 0 8px !important;
+}
+
+.sleep-timer-countdown {
+  font-size: 11px;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  display: inline-block;
+  text-align: center;
+  line-height: 1;
+}
+
+/* ---- Popover 面板 ---- */
+.sleep-timer-popover {
+  position: absolute;
+  right: 0;
+  bottom: calc(100% + 8px);
+  width: 228px;
+  padding: 14px 16px;
+
+  border: 1px solid var(--echo-polish-border, rgba(38, 40, 46, 0.12));
+  border-radius: 16px;
+  background: var(--echo-polish-surface-strong, rgba(255, 255, 255, 0.96));
+  box-shadow:
+    0 18px 42px rgba(36, 39, 48, 0.13),
+    inset 0 1px 0 rgba(255, 255, 255, 0.72);
+  backdrop-filter: blur(20px) saturate(1.15);
+
+  opacity: 0;
+  pointer-events: none;
+  transform: translateY(8px) scale(0.97);
+  transform-origin: calc(100% - 17px) 100%;
+  transition:
+    opacity 160ms ease,
+    transform 180ms cubic-bezier(0.22, 1, 0.36, 1);
+
+  z-index: 20;
+}
+
+.sleep-timer-popover[data-open="true"] {
+  opacity: 1;
+  pointer-events: auto;
+  transform: translateY(0) scale(1);
+}
+
+/* ---- 标题 ---- */
+.st-popover-title {
+  color: var(--theme-heading-text, #1e2025);
+  font-size: 13px;
+  font-weight: 650;
+  margin-bottom: 12px;
+  letter-spacing: 0.01em;
+}
+
+/* ---- 运行态（倒计时）---- */
+.st-popover-running {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 6px 0 4px;
+}
+
+.st-countdown {
+  font-size: 28px;
+  font-weight: 750;
+  font-variant-numeric: tabular-nums;
+  color: var(--echo-polish-accent-text, var(--color-accent-strong, #3239c7));
+  line-height: 1.1;
+  letter-spacing: -0.02em;
+}
+
+.st-hint {
+  font-size: 11px;
+  color: var(--theme-muted-text, #6c7179);
+  margin-top: 4px;
+}
+
+.st-cancel-btn {
+  display: inline-flex !important;
+  align-items: center !important;
+  justify-content: center !important;
+  margin-top: 10px;
+  width: 100% !important;
+  height: auto !important;
+  min-height: 32px;
+  font-size: 12px;
+  font-weight: 500;
+  padding: 8px 16px;
+  border-radius: 8px !important;
+  border-color: var(--echo-polish-border) !important;
+  background: var(--echo-polish-button-bg) !important;
+  color: var(--theme-page-text) !important;
+  box-shadow: none !important;
+  transition: all 150ms ease !important;
+  white-space: nowrap;
+}
+
+.st-cancel-btn:hover:not(:disabled) {
+  background: var(--echo-polish-active-bg) !important;
+  border-color: var(--echo-polish-active-border) !important;
+  transform: translateY(-1px) !important;
+}
+
+.st-cancel-btn:active:not(:disabled) {
+  transform: scale(0.97) !important;
+}
+
+/* ---- 行为选择栏 ---- */
+.st-action-bar {
+  display: flex;
+  gap: 6px;
+  margin-bottom: 10px;
+}
+
+.st-action-btn {
+  flex: 1;
+  padding: 5px 0;
+  font-size: 11.5px;
+  font-weight: 500;
+  color: var(--theme-muted-text, #6c7179);
+  border: 1px solid var(--echo-polish-border, rgba(38, 40, 46, 0.12)) !important;
+  border-radius: 8px !important;
+  background: var(--echo-polish-button-bg, rgba(255, 255, 255, 0.76)) !important;
+  box-shadow: none !important;
+  transition: all 150ms ease !important;
+}
+
+.st-action-btn:hover {
+  color: var(--theme-heading-text, #1e2025) !important;
+  background: var(--echo-polish-button-bg-hover, rgba(255, 255, 255, 0.98)) !important;
+  border-color: var(--echo-polish-border-strong, rgba(38, 40, 46, 0.18)) !important;
+  transform: translateY(-1px) !important;
+}
+
+.st-action-btn.is-active {
+  color: var(--echo-polish-accent-text, #3239c7) !important;
+  background: var(--echo-polish-active-bg, rgba(236, 238, 255, 0.86)) !important;
+  border-color: var(--echo-polish-active-border, rgba(75, 85, 232, 0.24)) !important;
+  font-weight: 600;
+}
+
+.st-action-btn:active:not(:disabled) {
+  transform: scale(0.95) !important;
+}
+
+/* ---- 渐弱开关行 ---- */
+.st-fade-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 6px 0;
+  cursor: pointer;
+  user-select: none;
+  margin-bottom: 8px;
+}
+
+.st-label {
+  font-size: 12px;
+  color: var(--theme-muted-text, #6c7179);
+}
+
+/* Toggle 开关 */
+.st-toggle {
+  position: relative;
+  width: 34px;
+  height: 18px;
+  border-radius: 9px;
+  background: var(--theme-control-bg, rgba(38, 40, 46, 0.1));
+  border: 1px solid var(--echo-polish-border, rgba(38, 40, 46, 0.1));
+  transition: background 200ms ease, border-color 200ms ease;
+  flex-shrink: 0;
+}
+
+.st-toggle.is-on {
+  background: var(--color-accent, #4b55e8);
+  border-color: transparent;
+}
+
+.st-toggle-knob {
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: #fff;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.18);
+  transition: left 200ms cubic-bezier(0.22, 1, 0.36, 1), transform 200ms ease;
+}
+
+.st-toggle.is-on .st-toggle-knob {
+  left: 18px;
+}
+
+/* ---- 预设时长网格 ---- */
+.st-preset-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 6px;
+  margin-bottom: 8px;
+}
+
+.st-preset-btn {
+  padding: 7px 4px;
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--theme-page-text, #2d3036);
+  border: 1px solid var(--echo-polish-border, rgba(38, 40, 46, 0.1)) !important;
+  border-radius: 8px !important;
+  background: var(--echo-polish-surface, rgba(255, 255, 255, 0.72)) !important;
+  box-shadow: none !important;
+  transition: all 140ms ease !important;
+}
+
+.st-preset-btn:hover {
+  background: var(--echo-polish-button-bg-hover, rgba(255, 255, 255, 0.96)) !important;
+  border-color: var(--echo-polish-border-strong, rgba(38, 40, 46, 0.16)) !important;
+  color: var(--echo-polish-accent-text, #3239c7) !important;
+  transform: translateY(-1px) scale(1.02) !important;
+}
+
+.st-preset-btn:active:not(:disabled) {
+  transform: scale(0.95) !important;
+}
+
+/* ---- 自定义输入行 ---- */
+.st-custom-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding-top: 4px;
+}
+
+.st-input {
+  width: 52px;
+  height: 30px;
+  padding: 0 6px;
+  font-size: 12px;
+  text-align: center;
+  color: var(--theme-page-text, #2d3036);
+  border: 1px solid var(--theme-field-border, rgba(38, 40, 46, 0.12));
+  border-radius: 8px;
+  background: var(--theme-field-bg, rgba(255, 255, 255, 0.86));
+  outline: none;
+  transition: border-color 150ms ease, box-shadow 150ms ease;
+  /* 移除 number input 箭头 */
+  -moz-appearance: textfield;
+}
+
+.st-input::-webkit-inner-spin-button,
+.st-input::-webkit-outer-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+
+.st-input:focus {
+  border-color: var(--echo-polish-accent-text, #3239c7);
+  box-shadow: 0 0 0 3px var(--theme-accent-bg, rgba(75, 85, 232, 0.12));
+}
+
+.st-unit {
+  font-size: 12px;
+  color: var(--theme-muted-text, #6c7179);
+  white-space: nowrap;
+}
+
+.st-confirm-btn {
+  flex: 1;
+  max-width: 56px;
+  height: 30px;
+  padding: 0;
+  font-size: 11.5px;
+  font-weight: 550;
+  color: #ffffff;
+  border: none !important;
+  border-radius: 8px !important;
+  background: linear-gradient(135deg, var(--color-accent, #4b55e8), var(--color-accent-strong, #3239c7)) !important;
+  box-shadow: 0 2px 8px rgba(75, 85, 232, 0.25) !important;
+  cursor: pointer;
+  opacity: 1;
+  transition: all 150ms ease !important;
+  margin-left: auto;
+}
+
+.st-confirm-btn:hover:not(:disabled) {
+  filter: brightness(1.08);
+  box-shadow: 0 4px 12px rgba(75, 85, 232, 0.35) !important;
+  transform: translateY(-1px) !important;
+}
+
+.st-confirm-btn:active:not(:disabled) {
+  transform: scale(0.95) !important;
+}
+
+.st-confirm-btn:disabled {
+  opacity: 0.35;
+  cursor: default;
+  box-shadow: none !important;
+  filter: none !important;
+}
+
 .audio-drawer-root {
   position: fixed;
   inset: 0;

--- a/src/shared/constants/ipcChannels.ts
+++ b/src/shared/constants/ipcChannels.ts
@@ -482,6 +482,10 @@ export const IpcChannels = {
   RoomCorrectionSetEnabled: 'room-correction:set-enabled',
   RoomCorrectionSetTrim: 'room-correction:set-trim',
   RoomCorrectionClear: 'room-correction:clear',
+  SleepTimerStart: 'sleep-timer:start',
+  SleepTimerCancel: 'sleep-timer:cancel',
+  SleepTimerGetStatus: 'sleep-timer:get-status',
+  SleepTimerOnTick: 'sleep-timer:on-tick',
 } as const;
 
 export type IpcChannel = (typeof IpcChannels)[keyof typeof IpcChannels];

--- a/src/shared/types/sleepTimer.ts
+++ b/src/shared/types/sleepTimer.ts
@@ -1,0 +1,26 @@
+/** 睡眠定时器到期动作 */
+export type SleepTimerAction = 'pause' | 'stop' | 'quit';
+
+/** 睡眠定时器状态 */
+export type SleepTimerStatus = {
+  /** 是否正在倒计时 */
+  isActive: boolean;
+  /** 剩余毫秒数 */
+  remainingMs: number;
+  /** 到期动作 */
+  action: SleepTimerAction;
+  /** 是否启用淡出 */
+  fadeOutEnabled: boolean;
+  /** 设定时长（分钟） */
+  durationMinutes: number;
+};
+
+/** 启动睡眠定时器的请求参数 */
+export type SleepTimerStartRequest = {
+  /** 倒计时分钟数 */
+  durationMinutes: number;
+  /** 到期动作 */
+  action: SleepTimerAction;
+  /** 是否启用淡出 */
+  fadeOut: boolean;
+};


### PR DESCRIPTION
给 ECHO 加了个睡眠定时器，睡前听歌不用怕睡着了忘关了。
三种到期行为：暂停 / 停止 / 退出应用
渐弱开关：到期前先把音量慢慢降下来，不会突然吓一跳
预设时长：5/10/15/30/45/60 分钟 + 自定义（1~120 分钟）
倒计时显示：播放栏按钮上实时显示剩余时间
托盘菜单：右键系统托盘图标也能看和取消定时器
多语言：中/繁/日/英 都翻译了
主题适配：自动跟着 ECHO 的主题变色，不会违和
动画效果：弹窗有过渡动画，按钮有 hover 效果
怎么实现的
主进程搞了个单例的 SleepTimerService，每秒 tick 倒计时
IPC 通道用的 `{domain}:{action}` 命名规范，跟项目保持一致
渲染进程是 React 组件（Button + Popover）
暂停功能用了 DOM 点击 fallback 方案，因为直接调 API 在 sandbox 环境下不太稳定
测试情况
写了22 个单元测试，核心逻辑全覆盖了
改了多少东西
新增 7 个文件（Service、IPC、类型定义、组件、测试）
改了 9 个文件（i18n 四语言翻译、样式、托盘菜单等）
如需查看我的步骤：我在fork 仓库里拆成了 PRD (#1) 和 6 个垂直切片 (#2~#7)
<img width="332" height="381" alt="1" src="https://github.com/user-attachments/assets/3a47cd45-c249-422a-acbe-df25477eaac7" />
